### PR TITLE
Added increment stat event callback

### DIFF
--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -54,6 +54,7 @@ protected:
 
 private:
   void handleStateChanged(packml_sm::AbstractStateMachine& state_machine, const packml_sm::StateChangedEventArgs& args);
+  void handleIncrementEvent(packml_sm::AbstractStateMachine& state_machine, const EventArgs& args);
   void getCurrentStats(packml_msgs::Stats& out_stats);
   bool getStats(packml_msgs::GetStats::Request& req, packml_msgs::GetStats::Response& response);
   bool resetStats(packml_msgs::ResetStats::Request& req, packml_msgs::ResetStats::Response& response);

--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -54,6 +54,7 @@ PackmlRos::PackmlRos(ros::NodeHandle nh, ros::NodeHandle pn, std::shared_ptr<pac
   }
 
   sm_->stateChangedEvent.bind_member_func(this, &PackmlRos::handleStateChanged);
+  sm_->incrementEvent.bind_member_func(this, &PackmlRos::handleIncrementEvent);
   sm_->activate();
 
 }
@@ -63,6 +64,7 @@ PackmlRos::~PackmlRos()
   if (sm_ != nullptr)
   {
     sm_->stateChangedEvent.unbind_member_func(this, &PackmlRos::handleStateChanged);
+    sm_->incrementEvent.unbind_member_func(this, &PackmlRos::handleIncrementEvent);
   }
 }
 
@@ -171,6 +173,11 @@ void PackmlRos::handleStateChanged(packml_sm::AbstractStateMachine& state_machin
   }
 
   status_pub_.publish(status_msg_);
+  publishStats();
+}
+
+void PackmlRos::handleIncrementEvent(packml_sm::AbstractStateMachine& state_machine, const EventArgs& args)
+{
   publishStats();
 }
 

--- a/packml_sm/include/packml_sm/abstract_state_machine.h
+++ b/packml_sm/include/packml_sm/abstract_state_machine.h
@@ -38,6 +38,8 @@ public:
   EventHandler<AbstractStateMachine, StateChangedEventArgs> stateChangedEvent; /** Triggered during a state changed
                                                                                   event. */
 
+  EventHandler<AbstractStateMachine, EventArgs> incrementEvent; /** Triggered during an increment stat event. */
+
   /**
    * @brief Constructor for AbstractStateMachine.
    *
@@ -398,6 +400,12 @@ protected:
    * @param value The name of the new value.
    */
   void invokeStateChangedEvent(const std::string& name, StatesEnum value);
+
+  /**
+   * @brief Call to invoke a stat incremented event.
+   *
+   */
+  void invokeIncrementEvent();
 
   /**
    * @brief Override to call implementations version of start command.

--- a/packml_sm/src/abstract_state_machine.cpp
+++ b/packml_sm/src/abstract_state_machine.cpp
@@ -364,24 +364,28 @@ void AbstractStateMachine::incrementMapStatItem(std::map<int16_t, PackmlStatsIte
 
 void AbstractStateMachine::incrementErrorStatItem(int16_t id, int32_t count, double duration)
 {
+  invokeIncrementEvent();
   std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
   incrementMapStatItem(itemized_error_map_, id, count, duration);
 }
 
 void AbstractStateMachine::incrementQualityStatItem(int16_t id, int32_t count, double duration)
 {
+  invokeIncrementEvent();
   std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
   incrementMapStatItem(itemized_quality_map_, id, count, duration);
 }
 
 void AbstractStateMachine::incrementSuccessCount()
 {
+  invokeIncrementEvent();
   std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
   success_count_++;
 }
 
 void AbstractStateMachine::incrementFailureCount()
 {
+  invokeIncrementEvent();
   std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
   failure_count_++;
 }
@@ -396,6 +400,11 @@ void AbstractStateMachine::invokeStateChangedEvent(const std::string& name, Stat
 {
   updateClock(value);
   stateChangedEvent.invoke(*this, { name, value });
+}
+
+void AbstractStateMachine::invokeIncrementEvent()
+{
+  incrementEvent.invoke(*this, {});
 }
 
 void AbstractStateMachine::updateClock(StatesEnum new_state)


### PR DESCRIPTION
Extension of previous publish_stats pull request: https://github.com/plusone-robotics/packml/pull/3

This pull request adds an event callback to publish stats whenever a stat is incremented.

Same test logs as previous pull request.