### PR TITLE
Save load stats

### DIFF
--- a/packml_msgs/CMakeLists.txt
+++ b/packml_msgs/CMakeLists.txt
@@ -19,6 +19,7 @@ add_service_files(
     ModeChange.srv
     Transition.srv
     ResetStats.srv
+    LoadStats.srv
 )
 
 

--- a/packml_msgs/srv/LoadStats.srv
+++ b/packml_msgs/srv/LoadStats.srv
@@ -1,0 +1,6 @@
+# Load packml state machine statistics, overriding current statistics
+
+# State machine statistics request
+Stats stats          # The current packml state machine statistics
+---
+# Empty response

--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -60,6 +60,7 @@ private:
   bool getStats(packml_msgs::GetStats::Request& req, packml_msgs::GetStats::Response& response);
   bool resetStats(packml_msgs::ResetStats::Request& req, packml_msgs::ResetStats::Response& response);
   bool loadStats(packml_msgs::LoadStats::Request& req, packml_msgs::LoadStats::Response& response);
+  packml_sm::PackmlStatsSnapshot populateStatsSnapshot(const packml_msgs::Stats& msg);
   void publishStatsCb(const ros::TimerEvent& timer_event);
   void publishStats();
 };

--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -22,6 +22,7 @@
 
 #include <packml_msgs/GetStats.h>
 #include <packml_msgs/ResetStats.h>
+#include <packml_msgs/LoadStats.h>
 #include <packml_msgs/Transition.h>
 #include <packml_msgs/Status.h>
 #include <packml_msgs/Stats.h>
@@ -46,6 +47,7 @@ protected:
   ros::ServiceServer trans_server_;
   ros::ServiceServer reset_stats_server_;
   ros::ServiceServer get_stats_server_;
+  ros::ServiceServer load_stats_server_;
   packml_msgs::Status status_msg_;
   float stats_publish_period_;
   ros::Timer stats_timer_;
@@ -57,6 +59,7 @@ private:
   void getCurrentStats(packml_msgs::Stats& out_stats);
   bool getStats(packml_msgs::GetStats::Request& req, packml_msgs::GetStats::Response& response);
   bool resetStats(packml_msgs::ResetStats::Request& req, packml_msgs::ResetStats::Response& response);
+  bool loadStats(packml_msgs::LoadStats::Request& req, packml_msgs::LoadStats::Response& response);
   void publishStatsCb(const ros::TimerEvent& timer_event);
   void publishStats();
 };

--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -36,6 +36,7 @@ PackmlRos::PackmlRos(ros::NodeHandle nh, ros::NodeHandle pn, std::shared_ptr<pac
   trans_server_ = packml_node.advertiseService("transition", &PackmlRos::transRequest, this);
   reset_stats_server_ = packml_node.advertiseService("reset_stats", &PackmlRos::resetStats, this);
   get_stats_server_ = packml_node.advertiseService("get_stats", &PackmlRos::getStats, this);
+  load_stats_server_ = packml_node.advertiseService("load_stats", &PackmlRos::loadStats, this);
 
   status_msg_ = packml_msgs::initStatus(pn.getNamespace());
 
@@ -257,5 +258,10 @@ void PackmlRos::publishStats()
   packml_msgs::Stats stats;
   getCurrentStats(stats);
   stats_pub_.publish(stats);
+}
+
+bool PackmlRos::loadStats(packml_msgs::LoadStats::Request &req, packml_msgs::LoadStats::Response &response)
+{
+  ROS_ERROR_STREAM("PACKML_STATS_LOADER SIDE " << req.stats.availability);
 }
 }  // namespace kitsune_robot

--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -250,6 +250,7 @@ packml_sm::PackmlStatsSnapshot PackmlRos::populateStatsSnapshot(const packml_msg
     item.duration = error_item.duration.data.toSec();
     itemized_error_map.insert(std::pair<int16_t, packml_sm::PackmlStatsItemized>(error_item.id, item));
   }
+  snapshot.itemized_error_map = itemized_error_map;
 
   std::map<int16_t, packml_sm::PackmlStatsItemized> itemized_quality_map;
   for (const auto& quality_item : msg.quality_items)
@@ -258,8 +259,9 @@ packml_sm::PackmlStatsSnapshot PackmlRos::populateStatsSnapshot(const packml_msg
     item.id = quality_item.id;
     item.count = quality_item.count;
     item.duration = quality_item.duration.data.toSec();
-    itemized_error_map.insert(std::pair<int16_t, packml_sm::PackmlStatsItemized>(quality_item.id, item));
+    itemized_quality_map.insert(std::pair<int16_t, packml_sm::PackmlStatsItemized>(quality_item.id, item));
   }
+  snapshot.itemized_quality_map = itemized_quality_map;
 
   return snapshot;
 }

--- a/packml_sm/include/packml_sm/abstract_state_machine.h
+++ b/packml_sm/include/packml_sm/abstract_state_machine.h
@@ -290,6 +290,13 @@ public:
   void resetStats();
 
   /**
+   * @brief Load all of the tracked states.
+   *
+   * @param snapshot snapshot stats data used to load stats
+   */
+  void loadStats(const PackmlStatsSnapshot& snapshot);
+
+  /**
    * @brief Call to increment or add a specific Itemized error stat.
    *
    */
@@ -490,6 +497,14 @@ private:
    * @return double Returns the total time spent in the given state.
    */
   double getStateDuration(StatesEnum state);
+
+  /**
+   * @brief Setter for the given state duration.
+   *
+   * @param state The state of interest.
+   * @return double Returns the total time spent in the given state.
+   */
+  void setStateDuration(StatesEnum state, double duration);
 
   /**
    * @brief Accessor for the total duration of the state machine.

--- a/packml_sm/src/abstract_state_machine.cpp
+++ b/packml_sm/src/abstract_state_machine.cpp
@@ -229,6 +229,23 @@ void AbstractStateMachine::getCurrentStatSnapshot(PackmlStatsSnapshot& snapshot_
   snapshot_out.itemized_quality_map = itemized_quality_map_;
 }
 
+void AbstractStateMachine::loadStats(const PackmlStatsSnapshot &snapshot)
+{
+  setStateDuration(StatesEnum::IDLE, snapshot.idle_duration);
+  setStateDuration(StatesEnum::EXECUTE, snapshot.exe_duration);
+  setStateDuration(StatesEnum::HELD, snapshot.held_duration);
+  setStateDuration(StatesEnum::SUSPENDED, snapshot.susp_duration);
+  setStateDuration(StatesEnum::COMPLETE, snapshot.cmplt_duration);
+  setStateDuration(StatesEnum::STOPPED, snapshot.stop_duration);
+  setStateDuration(StatesEnum::ABORTED, snapshot.abort_duration);
+  success_count_ = snapshot.success_count;
+  failure_count_ = snapshot.fail_count;
+  itemized_error_map_ = snapshot.itemized_error_map;
+  itemized_quality_map_ = snapshot.itemized_quality_map;
+
+  std::cout << "LOADED SNAPSHOT !" << std::endl;
+}
+
 double AbstractStateMachine::getIdleTime()
 {
   return getStateDuration(StatesEnum::IDLE);
@@ -430,5 +447,11 @@ double AbstractStateMachine::getStateDuration(StatesEnum state)
   }
 
   return elapsed_time;
+}
+
+void AbstractStateMachine::setStateDuration(StatesEnum state, double duration)
+{
+  std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
+  duration_map_[state] = duration;
 }
 }  // namespace packml_sm

--- a/packml_sm/src/abstract_state_machine.cpp
+++ b/packml_sm/src/abstract_state_machine.cpp
@@ -242,8 +242,6 @@ void AbstractStateMachine::loadStats(const PackmlStatsSnapshot &snapshot)
   failure_count_ = snapshot.fail_count;
   itemized_error_map_ = snapshot.itemized_error_map;
   itemized_quality_map_ = snapshot.itemized_quality_map;
-
-  std::cout << "LOADED SNAPSHOT !" << std::endl;
 }
 
 double AbstractStateMachine::getIdleTime()

--- a/packml_sm/src/abstract_state_machine.cpp
+++ b/packml_sm/src/abstract_state_machine.cpp
@@ -229,21 +229,6 @@ void AbstractStateMachine::getCurrentStatSnapshot(PackmlStatsSnapshot& snapshot_
   snapshot_out.itemized_quality_map = itemized_quality_map_;
 }
 
-void AbstractStateMachine::loadStats(const PackmlStatsSnapshot &snapshot)
-{
-  setStateDuration(StatesEnum::IDLE, snapshot.idle_duration);
-  setStateDuration(StatesEnum::EXECUTE, snapshot.exe_duration);
-  setStateDuration(StatesEnum::HELD, snapshot.held_duration);
-  setStateDuration(StatesEnum::SUSPENDED, snapshot.susp_duration);
-  setStateDuration(StatesEnum::COMPLETE, snapshot.cmplt_duration);
-  setStateDuration(StatesEnum::STOPPED, snapshot.stop_duration);
-  setStateDuration(StatesEnum::ABORTED, snapshot.abort_duration);
-  success_count_ = snapshot.success_count;
-  failure_count_ = snapshot.fail_count;
-  itemized_error_map_ = snapshot.itemized_error_map;
-  itemized_quality_map_ = snapshot.itemized_quality_map;
-}
-
 double AbstractStateMachine::getIdleTime()
 {
   return getStateDuration(StatesEnum::IDLE);
@@ -356,6 +341,21 @@ void AbstractStateMachine::resetStats()
     itemized_it.second.count = 0;
     itemized_it.second.duration = 0;
   }
+}
+
+void AbstractStateMachine::loadStats(const PackmlStatsSnapshot &snapshot)
+{
+  setStateDuration(StatesEnum::IDLE, snapshot.idle_duration);
+  setStateDuration(StatesEnum::EXECUTE, snapshot.exe_duration);
+  setStateDuration(StatesEnum::HELD, snapshot.held_duration);
+  setStateDuration(StatesEnum::SUSPENDED, snapshot.susp_duration);
+  setStateDuration(StatesEnum::COMPLETE, snapshot.cmplt_duration);
+  setStateDuration(StatesEnum::STOPPED, snapshot.stop_duration);
+  setStateDuration(StatesEnum::ABORTED, snapshot.abort_duration);
+  success_count_ = snapshot.success_count;
+  failure_count_ = snapshot.fail_count;
+  itemized_error_map_ = snapshot.itemized_error_map;
+  itemized_quality_map_ = snapshot.itemized_quality_map;
 }
 
 void AbstractStateMachine::incrementMapStatItem(std::map<int16_t, PackmlStatsItemized>& itemized_map, int16_t id,

--- a/packml_sm/src/abstract_state_machine.cpp
+++ b/packml_sm/src/abstract_state_machine.cpp
@@ -345,6 +345,8 @@ void AbstractStateMachine::resetStats()
 
 void AbstractStateMachine::loadStats(const PackmlStatsSnapshot &snapshot)
 {
+  std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
+
   setStateDuration(StatesEnum::IDLE, snapshot.idle_duration);
   setStateDuration(StatesEnum::EXECUTE, snapshot.exe_duration);
   setStateDuration(StatesEnum::HELD, snapshot.held_duration);
@@ -352,6 +354,7 @@ void AbstractStateMachine::loadStats(const PackmlStatsSnapshot &snapshot)
   setStateDuration(StatesEnum::COMPLETE, snapshot.cmplt_duration);
   setStateDuration(StatesEnum::STOPPED, snapshot.stop_duration);
   setStateDuration(StatesEnum::ABORTED, snapshot.abort_duration);
+
   success_count_ = snapshot.success_count;
   failure_count_ = snapshot.fail_count;
   itemized_error_map_ = snapshot.itemized_error_map;
@@ -449,7 +452,6 @@ double AbstractStateMachine::getStateDuration(StatesEnum state)
 
 void AbstractStateMachine::setStateDuration(StatesEnum state, double duration)
 {
-  std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
   duration_map_[state] = duration;
 }
 }  // namespace packml_sm

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -234,11 +234,6 @@ TEST(Packml_CC, load_stats)
 {
   ROS_INFO_STREAM("CONTINUOUS CYCLE::Load stats");
   std::shared_ptr<AbstractStateMachine> sm = PackmlStateMachineContinuous::spawn();
-  EXPECT_FALSE(sm->isActive());
-  sm->setExecute(std::bind(success));
-  sm->activate();
-  ros::Duration(1.0).sleep();  // give time to start
-  EXPECT_TRUE(sm->isActive());
 
   packml_sm::PackmlStatsSnapshot snapshot_read;
   sm->getCurrentStatSnapshot(snapshot_read);
@@ -248,7 +243,7 @@ TEST(Packml_CC, load_stats)
   ASSERT_EQ(snapshot_read.susp_duration, 0);
   ASSERT_EQ(snapshot_read.cmplt_duration, 0);
   ASSERT_EQ(snapshot_read.stop_duration, 0);
-  ASSERT_TRUE(snapshot_read.abort_duration > 0);
+  ASSERT_EQ(snapshot_read.abort_duration, 0);
   ASSERT_EQ(snapshot_read.success_count, 0);
   ASSERT_EQ(snapshot_read.fail_count, 0);
   ASSERT_EQ(snapshot_read.itemized_error_map.size(), 0);
@@ -290,7 +285,7 @@ TEST(Packml_CC, load_stats)
   ASSERT_EQ(snapshot_read.susp_duration, 4);
   ASSERT_EQ(snapshot_read.cmplt_duration, 5);
   ASSERT_EQ(snapshot_read.stop_duration, 6);
-  ASSERT_TRUE(snapshot_read.abort_duration > 7);
+  ASSERT_EQ(snapshot_read.abort_duration, 7);
   ASSERT_EQ(snapshot_read.success_count, 8);
   ASSERT_EQ(snapshot_read.fail_count, 9);
   ASSERT_EQ(snapshot_read.itemized_error_map.at(123).id, 123);
@@ -300,9 +295,6 @@ TEST(Packml_CC, load_stats)
   ASSERT_EQ(snapshot_read.itemized_quality_map.at(111).count, 222);
   ASSERT_EQ(snapshot_read.itemized_quality_map.at(111).duration, 333);
 
-  sm->deactivate();
-  ros::Duration(1).sleep();
-  EXPECT_FALSE(sm->isActive());
   ROS_INFO_STREAM("load stats test complete");
 }
 

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -25,6 +25,8 @@
 #include "ros/duration.h"
 #include "ros/console.h"
 #include "ros/rate.h"
+#include "packml_sm/packml_stats_snapshot.h"
+#include "packml_sm/packml_stats_itemized.h"
 
 namespace packml_sm_test
 {
@@ -227,4 +229,81 @@ TEST(Packml_CC, state_diagram)
   EXPECT_FALSE(sm->isActive());
   ROS_INFO_STREAM("State diagram test complete");
 }
+
+TEST(Packml_CC, load_stats)
+{
+  ROS_INFO_STREAM("CONTINUOUS CYCLE::Load stats");
+  std::shared_ptr<AbstractStateMachine> sm = PackmlStateMachineContinuous::spawn();
+  EXPECT_FALSE(sm->isActive());
+  sm->setExecute(std::bind(success));
+  sm->activate();
+  ros::Duration(1.0).sleep();  // give time to start
+  EXPECT_TRUE(sm->isActive());
+
+  packml_sm::PackmlStatsSnapshot snapshot_read;
+  sm->getCurrentStatSnapshot(snapshot_read);
+  ASSERT_EQ(snapshot_read.idle_duration, 0);
+  ASSERT_EQ(snapshot_read.exe_duration, 0);
+  ASSERT_EQ(snapshot_read.held_duration, 0);
+  ASSERT_EQ(snapshot_read.susp_duration, 0);
+  ASSERT_EQ(snapshot_read.cmplt_duration, 0);
+  ASSERT_EQ(snapshot_read.stop_duration, 0);
+  ASSERT_TRUE(snapshot_read.abort_duration > 0);
+  ASSERT_EQ(snapshot_read.success_count, 0);
+  ASSERT_EQ(snapshot_read.fail_count, 0);
+  ASSERT_EQ(snapshot_read.itemized_error_map.size(), 0);
+  ASSERT_EQ(snapshot_read.itemized_quality_map.size(), 0);
+
+  packml_sm::PackmlStatsSnapshot snapshot_load;
+  snapshot_load.idle_duration = 1;
+  snapshot_load.exe_duration = 2;
+  snapshot_load.held_duration = 3;
+  snapshot_load.susp_duration = 4;
+  snapshot_load.cmplt_duration = 5;
+  snapshot_load.stop_duration = 6;
+  snapshot_load.abort_duration = 7;
+  snapshot_load.success_count = 8;
+  snapshot_load.fail_count = 9;
+
+  std::map<int16_t, packml_sm::PackmlStatsItemized> itemized_error_map;
+  packml_sm::PackmlStatsItemized error_item;
+  error_item.id = 123;
+  error_item.count = 456;
+  error_item.duration = 789;
+  itemized_error_map.insert(std::pair<int16_t, packml_sm::PackmlStatsItemized>(error_item.id, error_item));
+  snapshot_load.itemized_error_map = itemized_error_map;
+
+  std::map<int16_t, packml_sm::PackmlStatsItemized> itemized_quality_map;
+  packml_sm::PackmlStatsItemized quality_item;
+  quality_item.id = 111;
+  quality_item.count = 222;
+  quality_item.duration = 333;
+  itemized_quality_map.insert(std::pair<int16_t, packml_sm::PackmlStatsItemized>(quality_item.id, quality_item));
+  snapshot_load.itemized_quality_map = itemized_quality_map;
+
+  sm->loadStats(snapshot_load);
+
+  sm->getCurrentStatSnapshot(snapshot_read);
+  ASSERT_EQ(snapshot_read.idle_duration, 1);
+  ASSERT_EQ(snapshot_read.exe_duration, 2);
+  ASSERT_EQ(snapshot_read.held_duration, 3);
+  ASSERT_EQ(snapshot_read.susp_duration, 4);
+  ASSERT_EQ(snapshot_read.cmplt_duration, 5);
+  ASSERT_EQ(snapshot_read.stop_duration, 6);
+  ASSERT_TRUE(snapshot_read.abort_duration > 7);
+  ASSERT_EQ(snapshot_read.success_count, 8);
+  ASSERT_EQ(snapshot_read.fail_count, 9);
+  ASSERT_EQ(snapshot_read.itemized_error_map.at(123).id, 123);
+  ASSERT_EQ(snapshot_read.itemized_error_map.at(123).count, 456);
+  ASSERT_EQ(snapshot_read.itemized_error_map.at(123).duration, 789);
+  ASSERT_EQ(snapshot_read.itemized_quality_map.at(111).id, 111);
+  ASSERT_EQ(snapshot_read.itemized_quality_map.at(111).count, 222);
+  ASSERT_EQ(snapshot_read.itemized_quality_map.at(111).duration, 333);
+
+  sm->deactivate();
+  ros::Duration(1).sleep();
+  EXPECT_FALSE(sm->isActive());
+  ROS_INFO_STREAM("load stats test complete");
+}
+
 }

--- a/packml_stats_loader/CMakeLists.txt
+++ b/packml_stats_loader/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(packml_stats_loader)
+
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  packml_msgs
+  packml_ros
+  packml_sm
+  roscpp
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    packml_msgs
+    packml_ros
+    packml_sm
+    roscpp
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME}_lib
+  src/packml_stats_loader.cpp
+)
+add_dependencies(${PROJECT_NAME}_lib ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME}_lib ${catkin_LIBRARIES})
+
+add_executable(${PROJECT_NAME} src/packml_stats_loader_node.cpp)
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_lib ${catkin_LIBRARIES})

--- a/packml_stats_loader/CMakeLists.txt
+++ b/packml_stats_loader/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   packml_ros
   packml_sm
   roscpp
+  rosbag
 )
 
 catkin_package(
@@ -16,6 +17,7 @@ catkin_package(
     packml_ros
     packml_sm
     roscpp
+    rosbag
   INCLUDE_DIRS
     include
   LIBRARIES

--- a/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
+++ b/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019, PlusOne Robotics
+ * All rights reserved.
+*/
+
+#ifndef SRC_PACKML_STATS_LOADER_H
+#define SRC_PACKML_STATS_LOADER_H
+
+#include <ros/ros.h>
+
+namespace packml_stats_loader
+{
+
+  class PackmlStatsLoader
+  {
+  public:
+    /**
+     * @brief Constructor
+     * @param pnh Private node handle
+     */
+    PackmlStatsLoader(const ros::NodeHandle& pnh);
+
+  private:
+    ros::NodeHandle pnh_;
+  };
+
+}
+
+#endif //SRC_PACKML_STATS_LOADER_H

--- a/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
+++ b/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
@@ -29,7 +29,6 @@ namespace packml_stats_loader
     bool writeStats(const packml_msgs::GetStats::Response& get_stats_response);
 
     ros::NodeHandle pnh_;
-    bool load_stats_;
     std::string packml_stats_location_;
   };
 

--- a/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
+++ b/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
@@ -7,6 +7,10 @@
 #define SRC_PACKML_STATS_LOADER_H
 
 #include <ros/ros.h>
+#include <rosbag/bag.h>
+#include <rosbag/view.h>
+#include <packml_msgs/GetStats.h>
+#include <packml_msgs/Stats.h>
 
 namespace packml_stats_loader
 {
@@ -21,7 +25,12 @@ namespace packml_stats_loader
     PackmlStatsLoader(const ros::NodeHandle& pnh);
 
   private:
+    bool loadStats();
+    bool writeStats(const packml_msgs::GetStats::Response& get_stats_response);
+
     ros::NodeHandle pnh_;
+    bool load_stats_;
+    std::string packml_stats_location_;
   };
 
 }

--- a/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
+++ b/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
@@ -10,6 +10,7 @@
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
 #include <packml_msgs/GetStats.h>
+#include <packml_msgs/LoadStats.h>
 #include <packml_msgs/Stats.h>
 
 namespace packml_stats_loader

--- a/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
+++ b/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
@@ -24,11 +24,10 @@ namespace packml_stats_loader
      * @param pnh Private node handle
      */
     PackmlStatsLoader(const ros::NodeHandle& pnh);
-
-  private:
     packml_msgs::Stats loadStats();
     void writeStats(const packml_msgs::GetStats::Response& get_stats_response);
 
+  private:
     ros::NodeHandle pnh_;
     std::string packml_stats_location_;
   };

--- a/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
+++ b/packml_stats_loader/include/packml_stats_loader/packml_stats_loader.h
@@ -26,8 +26,8 @@ namespace packml_stats_loader
     PackmlStatsLoader(const ros::NodeHandle& pnh);
 
   private:
-    bool loadStats();
-    bool writeStats(const packml_msgs::GetStats::Response& get_stats_response);
+    packml_msgs::Stats loadStats();
+    void writeStats(const packml_msgs::GetStats::Response& get_stats_response);
 
     ros::NodeHandle pnh_;
     std::string packml_stats_location_;

--- a/packml_stats_loader/launch/packml_stats_loader.launch
+++ b/packml_stats_loader/launch/packml_stats_loader.launch
@@ -9,8 +9,8 @@
         <param name="packml_stats_location" value="$(arg packml_stats_location)"/>
         <param name="load_packml_stats" value="$(arg load_packml_stats)"/>
         <param name="save_stats_rate" value="$(arg save_stats_rate)"/>
-        <remap from="/packml_stats_loader/get_stats" to="/packml_ros_node/packml/get_stats"/>
-        <remap from="/packml_stats_loader/load_stats" to="/packml_ros_node/packml/load_stats"/>
+        <remap from="packml_stats_loader/get_stats" to="/packml_ros_node/packml/get_stats"/>
+        <remap from="packml_stats_loader/load_stats" to="/packml_ros_node/packml/load_stats"/>
     </node>
 
     <include file="$(find packml_ros)/launch/packml_ros.launch"/>

--- a/packml_stats_loader/launch/packml_stats_loader.launch
+++ b/packml_stats_loader/launch/packml_stats_loader.launch
@@ -3,7 +3,7 @@
 
     <arg name="packml_stats_location" default="$(find packml_stats_loader)/config/packml_stats.bag" doc="Location to save and load packml stats from"/>
     <arg name="load_packml_stats" default="true" doc="Flag to load stats or not"/>
-    <arg name="save_stats_rate" default="0.1" doc="Rate to write stats to disk in Hz. A value <= 0 will not save at all"/>
+    <arg name="save_stats_rate" default="0.1" doc="Rate to write stats to disk in Hz. A value of 0 or less will not save at all"/>
 
     <node name="packml_stats_loader" pkg="packml_stats_loader" type="packml_stats_loader" output="screen">
         <param name="packml_stats_location" value="$(arg packml_stats_location)"/>

--- a/packml_stats_loader/launch/packml_stats_loader.launch
+++ b/packml_stats_loader/launch/packml_stats_loader.launch
@@ -3,7 +3,7 @@
 
     <arg name="packml_stats_location" default="$(find packml_stats_loader)/config/packml_stats.bag" doc="Location to save and load packml stats from"/>
     <arg name="load_packml_stats" default="true" doc="Flag to load stats or not"/>
-    <arg name="save_stats_rate" default="1.0" doc="Rate to write stats to disk"/>
+    <arg name="save_stats_rate" default="0.1" doc="Rate to write stats to disk in Hz. A value <= 0 will not save at all"/>
 
     <node name="packml_stats_loader" pkg="packml_stats_loader" type="packml_stats_loader" output="screen">
         <param name="packml_stats_location" value="$(arg packml_stats_location)"/>

--- a/packml_stats_loader/launch/packml_stats_loader.launch
+++ b/packml_stats_loader/launch/packml_stats_loader.launch
@@ -1,7 +1,16 @@
 <?xml version="1.0"?>
 <launch>
 
+    <arg name="packml_stats_location" default="$(find packml_stats_loader)/config/packml_stats.bag" doc="Location to save and load packml stats from"/>
+    <arg name="load_stats" default="true" doc="Flag to load stats or not"/>
+    <arg name="save_stats_rate" default="1.0" doc="Rate to write stats to disk"/>
+
     <node name="packml_stats_loader" pkg="packml_stats_loader" type="packml_stats_loader" output="screen">
+        <param name="packml_stats_location" value="$(arg packml_stats_location)"/>
+        <param name="load_stats" value="$(arg load_stats)"/>
+        <remap from="/packml_stats_loader/get_stats" to="/packml_ros_node/packml/get_stats"/>
     </node>
+
+    <include file="$(find packml_ros)/launch/packml_ros.launch"/>
 
 </launch>

--- a/packml_stats_loader/launch/packml_stats_loader.launch
+++ b/packml_stats_loader/launch/packml_stats_loader.launch
@@ -2,14 +2,15 @@
 <launch>
 
     <arg name="packml_stats_location" default="$(find packml_stats_loader)/config/packml_stats.bag" doc="Location to save and load packml stats from"/>
-    <arg name="load_stats" default="true" doc="Flag to load stats or not"/>
+    <arg name="load_packml_stats" default="true" doc="Flag to load stats or not"/>
     <arg name="save_stats_rate" default="1.0" doc="Rate to write stats to disk"/>
 
     <node name="packml_stats_loader" pkg="packml_stats_loader" type="packml_stats_loader" output="screen">
         <param name="packml_stats_location" value="$(arg packml_stats_location)"/>
-        <param name="load_stats" value="$(arg load_stats)"/>
+        <param name="load_packml_stats" value="$(arg load_packml_stats)"/>
         <param name="save_stats_rate" value="$(arg save_stats_rate)"/>
         <remap from="/packml_stats_loader/get_stats" to="/packml_ros_node/packml/get_stats"/>
+        <remap from="/packml_stats_loader/load_stats" to="/packml_ros_node/packml/load_stats"/>
     </node>
 
     <include file="$(find packml_ros)/launch/packml_ros.launch"/>

--- a/packml_stats_loader/launch/packml_stats_loader.launch
+++ b/packml_stats_loader/launch/packml_stats_loader.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<launch>
+
+    <node name="packml_stats_loader" pkg="packml_stats_loader" type="packml_stats_loader" output="screen">
+    </node>
+
+</launch>

--- a/packml_stats_loader/launch/packml_stats_loader.launch
+++ b/packml_stats_loader/launch/packml_stats_loader.launch
@@ -8,6 +8,7 @@
     <node name="packml_stats_loader" pkg="packml_stats_loader" type="packml_stats_loader" output="screen">
         <param name="packml_stats_location" value="$(arg packml_stats_location)"/>
         <param name="load_stats" value="$(arg load_stats)"/>
+        <param name="save_stats_rate" value="$(arg save_stats_rate)"/>
         <remap from="/packml_stats_loader/get_stats" to="/packml_ros_node/packml/get_stats"/>
     </node>
 

--- a/packml_stats_loader/package.xml
+++ b/packml_stats_loader/package.xml
@@ -16,5 +16,6 @@
   <depend>packml_ros</depend>
   <depend>packml_sm</depend>
   <depend>roscpp</depend>
+  <depend>rosbag</depend>
 
 </package>

--- a/packml_stats_loader/package.xml
+++ b/packml_stats_loader/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>packml_stats_loader</name>
+  <version>1000.1.0</version>
+  <description>Utility nodes for packml</description>
+
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <author>Shaun Edwards</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>packml_msgs</depend>
+  <depend>packml_ros</depend>
+  <depend>packml_sm</depend>
+  <depend>roscpp</depend>
+
+</package>

--- a/packml_stats_loader/package.xml
+++ b/packml_stats_loader/package.xml
@@ -2,13 +2,13 @@
 <package format="2">
   <name>packml_stats_loader</name>
   <version>1000.1.0</version>
-  <description>Utility nodes for packml</description>
+  <description>Utility node that loads and saves packml stats</description>
 
-  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <maintainer email="charles.costello@plusonerobotics.com">Charles Costello</maintainer>
 
   <license>Apache 2.0</license>
 
-  <author>Shaun Edwards</author>
+  <author>Charles Costello</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -9,17 +9,15 @@ namespace packml_stats_loader
 {
   PackmlStatsLoader::PackmlStatsLoader(const ros::NodeHandle &pnh): pnh_(pnh)
   {
-
-    // Get params
     if (!pnh_.getParam("packml_stats_location", packml_stats_location_))
     {
       ROS_FATAL_STREAM("Missing param: packml_stats_location. Unable to load or save stats. Shutting down.");
       ros::shutdown();
     }
-    bool load_stats = false;
-    if (!pnh_.getParam("load_stats", load_stats))
+    bool load_packml_stats = false;
+    if (!pnh_.getParam("load_packml_stats", load_packml_stats))
     {
-      ROS_WARN_STREAM("Missing param: load_stats. Defaulting to false.");
+      ROS_WARN_STREAM("Missing param: load_packml_stats. Defaulting to false.");
     }
     float save_stats_rate = 1.0;
     if (!pnh_.getParam("save_stats_rate", save_stats_rate))
@@ -27,27 +25,25 @@ namespace packml_stats_loader
       ROS_WARN_STREAM("Missing param: save_stats_rate. Defaulting to 1.0Hz.");
     }
 
-    // Load stats
-    if (load_stats)
+    if (load_packml_stats)
     {
       if (!loadStats())
       {
-        ROS_ERROR_STREAM("Failed to load stats");
+        ROS_ERROR_STREAM("Failed to load packml stats");
       }
       else
       {
-        ROS_INFO_STREAM("Successfully loaded stats");
+        ROS_INFO_STREAM("Successfully loaded packml stats");
       }
     }
 
-    // Save stats
     ros::ServiceClient get_stats_client = pnh_.serviceClient<packml_msgs::GetStats>("get_stats");
     ros::service::waitForService(get_stats_client.getService());
     ros::Rate rate(save_stats_rate);
+    packml_msgs::GetStats get_stats_srv;
 
     while (ros::ok)
     {
-      packml_msgs::GetStats get_stats_srv;
       if (!get_stats_client.call(get_stats_srv))
       {
         ROS_ERROR_STREAM("Failed to call service " << get_stats_client.getService());
@@ -56,11 +52,11 @@ namespace packml_stats_loader
       {
         if (!writeStats(get_stats_srv.response))
         {
-          ROS_ERROR_STREAM("Failed to write stats");
+          ROS_ERROR_STREAM("Failed to write packml stats");
         }
         else
         {
-          ROS_INFO_STREAM("Successfully saved stats");
+          ROS_INFO_STREAM("Successfully wrote packml stats");
         }
       }
 
@@ -82,11 +78,25 @@ namespace packml_stats_loader
       return false;
     }
 
+    ros::ServiceClient load_stats_client = pnh_.serviceClient<packml_msgs::LoadStats>("load_stats");
+    ros::service::waitForService(load_stats_client.getService());
+
     for(const auto& message_instance : rosbag::View(bag))
     {
       if (message_instance.isType<packml_msgs::Stats>())
       {
-        auto message = message_instance.instantiate<packml_msgs::Stats>();
+        auto msg = message_instance.instantiate<packml_msgs::Stats>();
+        ROS_ERROR_STREAM("PACKML_STATS_LOADER SIDE " << msg->availability);
+        packml_msgs::LoadStats load_stats_srv;
+        load_stats_srv.request.stats = *msg;
+        if (!load_stats_client.call(load_stats_srv))
+        {
+          ROS_ERROR_STREAM("Failed to call service " << load_stats_client.getService());
+        }
+        else
+        {
+          ROS_INFO_STREAM("Successfully loaded packml stats");
+        }
       }
     }
 
@@ -97,6 +107,7 @@ namespace packml_stats_loader
   bool PackmlStatsLoader::writeStats(const packml_msgs::GetStats::Response& get_stats_response)
   {
     packml_msgs::Stats stats_msg = get_stats_response.stats;
+    ROS_INFO_STREAM(stats_msg.availability);
     rosbag::Bag bag;
 
     try

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -58,7 +58,7 @@ namespace packml_stats_loader
           }
           else
           {
-            ROS_INFO_STREAM("Successfully wrote packml stats");
+            ROS_DEBUG_STREAM("Successfully wrote packml stats");
           }
         }
 
@@ -89,16 +89,11 @@ namespace packml_stats_loader
       if (message_instance.isType<packml_msgs::Stats>())
       {
         auto msg = message_instance.instantiate<packml_msgs::Stats>();
-        ROS_ERROR_STREAM("PACKML_STATS_LOADER SIDE " << msg->availability);
         packml_msgs::LoadStats load_stats_srv;
         load_stats_srv.request.stats = *msg;
         if (!load_stats_client.call(load_stats_srv))
         {
           ROS_ERROR_STREAM("Failed to call service " << load_stats_client.getService());
-        }
-        else
-        {
-          ROS_INFO_STREAM("Successfully loaded packml stats");
         }
       }
     }
@@ -110,7 +105,6 @@ namespace packml_stats_loader
   bool PackmlStatsLoader::writeStats(const packml_msgs::GetStats::Response& get_stats_response)
   {
     packml_msgs::Stats stats_msg = get_stats_response.stats;
-    ROS_INFO_STREAM(stats_msg.availability);
     rosbag::Bag bag;
 
     try

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -78,9 +78,9 @@ namespace packml_stats_loader
     {
       bag.open(packml_stats_location_, rosbag::bagmode::Read);
     }
-    catch (const rosbag::BagException& exception)
+    catch (const rosbag::BagException& ex)
     {
-      ROS_FATAL_STREAM("Failed to open bag with exception: " << exception.what());
+      ROS_FATAL_STREAM("Failed to open bag with exception: " << ex.what());
       ros::shutdown();
     }
 
@@ -103,9 +103,9 @@ namespace packml_stats_loader
     {
       bag.open(packml_stats_location_, rosbag::bagmode::Write);
     }
-    catch (const rosbag::BagException& exception)
+    catch (const rosbag::BagException& ex)
     {
-      ROS_FATAL_STREAM("Failed to open bag with exception: " << exception.what());
+      ROS_FATAL_STREAM("Failed to open bag with exception: " << ex.what());
       ros::shutdown();
     }
 

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -10,20 +10,25 @@ namespace packml_stats_loader
   PackmlStatsLoader::PackmlStatsLoader(const ros::NodeHandle &pnh): pnh_(pnh)
   {
 
-    // Get stats location
+    // Get params
     if (!pnh_.getParam("packml_stats_location", packml_stats_location_))
     {
       ROS_FATAL_STREAM("Missing param: packml_stats_location. Unable to load or save stats. Shutting down.");
       ros::shutdown();
     }
-
-    // Load stats
-    if (!pnh_.getParam("load_stats", load_stats_))
+    bool load_stats = false;
+    if (!pnh_.getParam("load_stats", load_stats))
     {
       ROS_WARN_STREAM("Missing param: load_stats. Defaulting to false.");
-      load_stats_ = false;
     }
-    if (load_stats_)
+    float save_stats_rate = 1.0;
+    if (!pnh_.getParam("save_stats_rate", save_stats_rate))
+    {
+      ROS_WARN_STREAM("Missing param: save_stats_rate. Defaulting to 1.0Hz.");
+    }
+
+    // Load stats
+    if (load_stats)
     {
       if (!loadStats())
       {
@@ -33,29 +38,35 @@ namespace packml_stats_loader
       {
         ROS_INFO_STREAM("Successfully loaded stats");
       }
-
     }
 
     // Save stats
     ros::ServiceClient get_stats_client = pnh_.serviceClient<packml_msgs::GetStats>("get_stats");
     ros::service::waitForService(get_stats_client.getService());
-    packml_msgs::GetStats get_stats_srv;
-    if (!get_stats_client.call(get_stats_srv))
+    ros::Rate rate(save_stats_rate);
+
+    while (ros::ok)
     {
-      ROS_ERROR_STREAM("Failed to call service " << get_stats_client.getService());
-    }
-    else
-    {
-      if (!writeStats(get_stats_srv.response))
+      packml_msgs::GetStats get_stats_srv;
+      if (!get_stats_client.call(get_stats_srv))
       {
-        ROS_ERROR_STREAM("Failed to write stats");
+        ROS_ERROR_STREAM("Failed to call service " << get_stats_client.getService());
       }
       else
       {
-        ROS_INFO_STREAM("Successfully saved stats");
+        if (!writeStats(get_stats_srv.response))
+        {
+          ROS_ERROR_STREAM("Failed to write stats");
+        }
+        else
+        {
+          ROS_INFO_STREAM("Successfully saved stats");
+        }
       }
-    }
 
+      ros::spinOnce();
+      rate.sleep();
+    }
   }
 
   bool PackmlStatsLoader::loadStats()
@@ -76,7 +87,6 @@ namespace packml_stats_loader
       if (message_instance.isType<packml_msgs::Stats>())
       {
         auto message = message_instance.instantiate<packml_msgs::Stats>();
-        ROS_INFO_STREAM(message->availability);
       }
     }
 

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019, PlusOne Robotics
+ * All rights reserved.
+*/
+
+#include "packml_stats_loader/packml_stats_loader.h"
+
+namespace packml_stats_loader
+{
+  PackmlStatsLoader::PackmlStatsLoader(const ros::NodeHandle &pnh): pnh_(pnh)
+  {
+    ROS_ERROR_STREAM("TEST");
+  }
+}

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -9,6 +9,100 @@ namespace packml_stats_loader
 {
   PackmlStatsLoader::PackmlStatsLoader(const ros::NodeHandle &pnh): pnh_(pnh)
   {
-    ROS_ERROR_STREAM("TEST");
+
+    // Get stats location
+    if (!pnh_.getParam("packml_stats_location", packml_stats_location_))
+    {
+      ROS_FATAL_STREAM("Missing param: packml_stats_location. Unable to load or save stats. Shutting down.");
+      ros::shutdown();
+    }
+
+    // Load stats
+    if (!pnh_.getParam("load_stats", load_stats_))
+    {
+      ROS_WARN_STREAM("Missing param: load_stats. Defaulting to false.");
+      load_stats_ = false;
+    }
+    if (load_stats_)
+    {
+      if (!loadStats())
+      {
+        ROS_ERROR_STREAM("Failed to load stats");
+      }
+      else
+      {
+        ROS_INFO_STREAM("Successfully loaded stats");
+      }
+
+    }
+
+    // Save stats
+    ros::ServiceClient get_stats_client = pnh_.serviceClient<packml_msgs::GetStats>("get_stats");
+    ros::service::waitForService(get_stats_client.getService());
+    packml_msgs::GetStats get_stats_srv;
+    if (!get_stats_client.call(get_stats_srv))
+    {
+      ROS_ERROR_STREAM("Failed to call service " << get_stats_client.getService());
+    }
+    else
+    {
+      if (!writeStats(get_stats_srv.response))
+      {
+        ROS_ERROR_STREAM("Failed to write stats");
+      }
+      else
+      {
+        ROS_INFO_STREAM("Successfully saved stats");
+      }
+    }
+
   }
+
+  bool PackmlStatsLoader::loadStats()
+  {
+    rosbag::Bag bag;
+    try
+    {
+      bag.open(packml_stats_location_, rosbag::bagmode::Read);
+    }
+    catch (const std::exception &ex)
+    {
+      ROS_ERROR_STREAM(ex.what());
+      return false;
+    }
+
+    for(const auto& message_instance : rosbag::View(bag))
+    {
+      if (message_instance.isType<packml_msgs::Stats>())
+      {
+        auto message = message_instance.instantiate<packml_msgs::Stats>();
+        ROS_INFO_STREAM(message->availability);
+      }
+    }
+
+    bag.close();
+    return true;
+  }
+
+  bool PackmlStatsLoader::writeStats(const packml_msgs::GetStats::Response& get_stats_response)
+  {
+    packml_msgs::Stats stats_msg = get_stats_response.stats;
+    rosbag::Bag bag;
+
+    try
+    {
+      bag.open(packml_stats_location_, rosbag::bagmode::Write);
+    }
+    catch (const std::exception &ex)
+    {
+      ROS_ERROR_STREAM(ex.what());
+      return false;
+    }
+
+    bag.write("stats", ros::Time::now(), stats_msg);
+
+    bag.close();
+    return true;
+  }
+
 }

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -78,9 +78,9 @@ namespace packml_stats_loader
     {
       bag.open(packml_stats_location_, rosbag::bagmode::Read);
     }
-    catch (const std::exception &ex)
+    catch (const rosbag::BagException& exception)
     {
-      ROS_FATAL_STREAM("Failed to open bag with exception: " << ex.what());
+      ROS_FATAL_STREAM("Failed to open bag with exception: " << exception.what());
       ros::shutdown();
     }
 
@@ -103,9 +103,9 @@ namespace packml_stats_loader
     {
       bag.open(packml_stats_location_, rosbag::bagmode::Write);
     }
-    catch (const std::exception &ex)
+    catch (const rosbag::BagException& exception)
     {
-      ROS_FATAL_STREAM("Failed to open bag with exception: " << ex.what());
+      ROS_FATAL_STREAM("Failed to open bag with exception: " << exception.what());
       ros::shutdown();
     }
 

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -37,31 +37,34 @@ namespace packml_stats_loader
       }
     }
 
-    ros::ServiceClient get_stats_client = pnh_.serviceClient<packml_msgs::GetStats>("get_stats");
-    ros::service::waitForService(get_stats_client.getService());
-    ros::Rate rate(save_stats_rate);
-    packml_msgs::GetStats get_stats_srv;
-
-    while (ros::ok)
+    if (save_stats_rate > 0)
     {
-      if (!get_stats_client.call(get_stats_srv))
+      ros::ServiceClient get_stats_client = pnh_.serviceClient<packml_msgs::GetStats>("get_stats");
+      ros::service::waitForService(get_stats_client.getService());
+      ros::Rate rate(save_stats_rate);
+      packml_msgs::GetStats get_stats_srv;
+
+      while (ros::ok)
       {
-        ROS_ERROR_STREAM("Failed to call service " << get_stats_client.getService());
-      }
-      else
-      {
-        if (!writeStats(get_stats_srv.response))
+        if (!get_stats_client.call(get_stats_srv))
         {
-          ROS_ERROR_STREAM("Failed to write packml stats");
+          ROS_ERROR_STREAM("Failed to call service " << get_stats_client.getService());
         }
         else
         {
-          ROS_INFO_STREAM("Successfully wrote packml stats");
+          if (!writeStats(get_stats_srv.response))
+          {
+            ROS_ERROR_STREAM("Failed to write packml stats");
+          }
+          else
+          {
+            ROS_INFO_STREAM("Successfully wrote packml stats");
+          }
         }
-      }
 
-      ros::spinOnce();
-      rate.sleep();
+        ros::spinOnce();
+        rate.sleep();
+      }
     }
   }
 

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -9,6 +9,8 @@ namespace packml_stats_loader
 {
   PackmlStatsLoader::PackmlStatsLoader(const ros::NodeHandle &pnh): pnh_(pnh)
   {
+
+    // Get parameters
     if (!pnh_.getParam("packml_stats_location", packml_stats_location_))
     {
       ROS_FATAL_STREAM("Missing param: packml_stats_location. Unable to load or save stats. Shutting down.");
@@ -25,11 +27,17 @@ namespace packml_stats_loader
       ROS_WARN_STREAM("Missing param: save_stats_rate. Defaulting to 1.0Hz.");
     }
 
+    // Load stats
     if (load_packml_stats)
     {
-      if (!loadStats())
+      ros::ServiceClient load_stats_client = pnh_.serviceClient<packml_msgs::LoadStats>("load_stats");
+      ros::service::waitForService(load_stats_client.getService());
+      packml_msgs::LoadStats load_stats_srv;
+      load_stats_srv.request.stats = loadStats();
+
+      if (!load_stats_client.call(load_stats_srv))
       {
-        ROS_ERROR_STREAM("Failed to load packml stats");
+        ROS_ERROR_STREAM("Failed to call service " << load_stats_client.getService());
       }
       else
       {
@@ -37,6 +45,7 @@ namespace packml_stats_loader
       }
     }
 
+    // Save stats
     if (save_stats_rate > 0)
     {
       ros::ServiceClient get_stats_client = pnh_.serviceClient<packml_msgs::GetStats>("get_stats");
@@ -52,14 +61,7 @@ namespace packml_stats_loader
         }
         else
         {
-          if (!writeStats(get_stats_srv.response))
-          {
-            ROS_ERROR_STREAM("Failed to write packml stats");
-          }
-          else
-          {
-            ROS_DEBUG_STREAM("Successfully wrote packml stats");
-          }
+          writeStats(get_stats_srv.response);
         }
 
         ros::spinOnce();
@@ -68,7 +70,7 @@ namespace packml_stats_loader
     }
   }
 
-  bool PackmlStatsLoader::loadStats()
+  packml_msgs::Stats PackmlStatsLoader::loadStats()
   {
     rosbag::Bag bag;
     try
@@ -77,50 +79,39 @@ namespace packml_stats_loader
     }
     catch (const std::exception &ex)
     {
-      ROS_ERROR_STREAM(ex.what());
-      return false;
+      ROS_ERROR_STREAM("Failed to open bag with exception: " << ex.what());
+      ros::shutdown();
     }
-
-    ros::ServiceClient load_stats_client = pnh_.serviceClient<packml_msgs::LoadStats>("load_stats");
-    ros::service::waitForService(load_stats_client.getService());
 
     for(const auto& message_instance : rosbag::View(bag))
     {
       if (message_instance.isType<packml_msgs::Stats>())
       {
         auto msg = message_instance.instantiate<packml_msgs::Stats>();
-        packml_msgs::LoadStats load_stats_srv;
-        load_stats_srv.request.stats = *msg;
-        if (!load_stats_client.call(load_stats_srv))
-        {
-          ROS_ERROR_STREAM("Failed to call service " << load_stats_client.getService());
-        }
+        return *msg;
       }
     }
 
     bag.close();
-    return true;
   }
 
-  bool PackmlStatsLoader::writeStats(const packml_msgs::GetStats::Response& get_stats_response)
+  void PackmlStatsLoader::writeStats(const packml_msgs::GetStats::Response& get_stats_response)
   {
-    packml_msgs::Stats stats_msg = get_stats_response.stats;
     rosbag::Bag bag;
-
     try
     {
       bag.open(packml_stats_location_, rosbag::bagmode::Write);
     }
     catch (const std::exception &ex)
     {
-      ROS_ERROR_STREAM(ex.what());
-      return false;
+      ROS_FATAL_STREAM("Failed to open bag with exception: " << ex.what());
+      ros::shutdown();
     }
 
+    packml_msgs::Stats stats_msg = get_stats_response.stats;
     bag.write("stats", ros::Time::now(), stats_msg);
 
     bag.close();
-    return true;
   }
 
 }

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -37,7 +37,8 @@ namespace packml_stats_loader
 
       if (!load_stats_client.call(load_stats_srv))
       {
-        ROS_ERROR_STREAM("Failed to call service " << load_stats_client.getService());
+        ROS_FATAL_STREAM("Failed to call service " << load_stats_client.getService());
+        ros::shutdown();
       }
       else
       {
@@ -79,7 +80,7 @@ namespace packml_stats_loader
     }
     catch (const std::exception &ex)
     {
-      ROS_ERROR_STREAM("Failed to open bag with exception: " << ex.what());
+      ROS_FATAL_STREAM("Failed to open bag with exception: " << ex.what());
       ros::shutdown();
     }
 

--- a/packml_stats_loader/src/packml_stats_loader.cpp
+++ b/packml_stats_loader/src/packml_stats_loader.cpp
@@ -53,7 +53,7 @@ namespace packml_stats_loader
       ros::Rate rate(save_stats_rate);
       packml_msgs::GetStats get_stats_srv;
 
-      while (ros::ok)
+      while (ros::ok())
       {
         if (!get_stats_client.call(get_stats_srv))
         {

--- a/packml_stats_loader/src/packml_stats_loader_node.cpp
+++ b/packml_stats_loader/src/packml_stats_loader_node.cpp
@@ -11,6 +11,4 @@ int main(int argc, char** argv)
   ros::NodeHandle pnh("~");
 
   packml_stats_loader::PackmlStatsLoader packml_stats_loader(pnh);
-
-  ros::spin();
 }

--- a/packml_stats_loader/src/packml_stats_loader_node.cpp
+++ b/packml_stats_loader/src/packml_stats_loader_node.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019, PlusOne Robotics
+ * All rights reserved.
+*/
+
+#include "packml_stats_loader/packml_stats_loader.h"
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "packml_stats_loader");
+  ros::NodeHandle pnh("~");
+
+  packml_stats_loader::PackmlStatsLoader packml_stats_loader(pnh);
+}

--- a/packml_stats_loader/src/packml_stats_loader_node.cpp
+++ b/packml_stats_loader/src/packml_stats_loader_node.cpp
@@ -11,4 +11,6 @@ int main(int argc, char** argv)
   ros::NodeHandle pnh("~");
 
   packml_stats_loader::PackmlStatsLoader packml_stats_loader(pnh);
+
+  ros::spin();
 }


### PR DESCRIPTION
### Overview
Adds functionality to periodically save packml stats to disk and load them at start up. This is done through a new package, packml_stats_loader, and modifications to packml_ros and packml_sm for loading the stats.

### Local Testing logs
Before shutdown:
```
charlescostello@plusonerobotics:~/Projects/packml_save_ws$ rostopic echo /packml/stats
header: 
  seq: 3
  stamp: 
    secs: 1565302464
    nsecs:   9083425
  frame_id: ''
duration: 
  data: 
    secs: 14459
    nsecs:  83244011
idle_duration: 
  data: 
    secs: 6543
    nsecs:         0
exe_duration: 
  data: 
    secs: 123
    nsecs:         0
held_duration: 
  data: 
    secs: 2346
    nsecs:         0
susp_duration: 
  data: 
    secs: 22
    nsecs:         0
cmplt_duration: 
  data: 
    secs: 64
    nsecs:         0
stop_duration: 
  data: 
    secs: 5332
    nsecs:         0
abort_duration: 
  data: 
    secs: 29
    nsecs:  44555182
error_items: 
  - 
    id: 45
    count: 77
    duration: 
      data: 
        secs: 654
        nsecs:         0
  - 
    id: 123
    count: 98776
    duration: 
      data: 
        secs: 89
        nsecs:         0
quality_items: 
  - 
    id: 123
    count: 98776
    duration: 
      data: 
        secs: 89
        nsecs:         0
cycle_count: 0
success_count: 22
fail_count: 33
throughput: 0.0
availability: 0.627704977989
performance: 0.0
quality: 0.40000000596
overall_equipment_effectiveness: 0.0
---
``` 
And after startup:
```
charlescostello@plusonerobotics:~/Projects/packml_save_ws$ rostopic echo /packml/stats
header: 
  seq: 1
  stamp: 
    secs: 1565302508
    nsecs: 130321360
  frame_id: ''
duration: 
  data: 
    secs: 14473
    nsecs: 102988570
idle_duration: 
  data: 
    secs: 6543
    nsecs:         0
exe_duration: 
  data: 
    secs: 123
    nsecs:         0
held_duration: 
  data: 
    secs: 2346
    nsecs:         0
susp_duration: 
  data: 
    secs: 22
    nsecs:         0
cmplt_duration: 
  data: 
    secs: 64
    nsecs:         0
stop_duration: 
  data: 
    secs: 5332
    nsecs:         0
abort_duration: 
  data: 
    secs: 43
    nsecs:  68970644
error_items: 
  - 
    id: 45
    count: 77
    duration: 
      data: 
        secs: 654
        nsecs:         0
  - 
    id: 123
    count: 98776
    duration: 
      data: 
        secs: 89
        nsecs:         0
quality_items: 
  - 
    id: 123
    count: 98776
    duration: 
      data: 
        secs: 89
        nsecs:         0
cycle_count: 0
success_count: 22
fail_count: 33
throughput: 0.0
availability: 0.627096652985
performance: 0.0
quality: 0.40000000596
overall_equipment_effectiveness: 0.0
---
```

### Simulation Testing logs
Before shutdown:
```
charlescostello@plusonerobotics:~/Projects/packml_save_ws$ rostopic echo /packml/stats
header: 
  seq: 26
  stamp: 
    secs: 1565298416
    nsecs: 926592294
  frame_id: ''
duration: 
  data: 
    secs: 1617
    nsecs: 708035940
idle_duration: 
  data: 
    secs: 5
    nsecs:  75523011
exe_duration: 
  data: 
    secs: 425
    nsecs: 679679022
held_duration: 
  data: 
    secs: 0
    nsecs:         0
susp_duration: 
  data: 
    secs: 0
    nsecs:         0
cmplt_duration: 
  data: 
    secs: 0
    nsecs:         0
stop_duration: 
  data: 
    secs: 29
    nsecs:  82674918
abort_duration: 
  data: 
    secs: 1157
    nsecs: 851215620
error_items: []
quality_items: []
cycle_count: 0
success_count: 0
fail_count: 0
throughput: 0.0
availability: 0.266286700964
performance: 0.0
quality: 0.0
overall_equipment_effectiveness: 0.0
---
```

And after startup:
```
charlescostello@plusonerobotics:~/Projects/packml_save_ws$ rostopic echo /packml/stats
header: 
  seq: 10
  stamp: 
    secs: 1565298580
    nsecs: 504292626
  frame_id: ''
duration: 
  data: 
    secs: 1621
    nsecs: 639911376
idle_duration: 
  data: 
    secs: 5
    nsecs:  75523011
exe_duration: 
  data: 
    secs: 425
    nsecs: 679679022
held_duration: 
  data: 
    secs: 0
    nsecs:         0
susp_duration: 
  data: 
    secs: 0
    nsecs:         0
cmplt_duration: 
  data: 
    secs: 0
    nsecs:         0
stop_duration: 
  data: 
    secs: 29
    nsecs:  82674918
abort_duration: 
  data: 
    secs: 1161
    nsecs: 783396896
error_items: []
quality_items: []
cycle_count: 0
success_count: 0
fail_count: 0
throughput: 0.0
availability: 0.265640884638
performance: 0.0
quality: 0.0
overall_equipment_effectiveness: 0.0
---
```