### PR TITLE
Interval stats

### DIFF
--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -60,7 +60,7 @@ protected:
 private:
   void handleStateChanged(packml_sm::AbstractStateMachine& state_machine, const packml_sm::StateChangedEventArgs& args);
   void getCurrentStats(packml_msgs::Stats& out_stats);
-  void getStatsTransaction(packml_msgs::Stats& out_stats, double duration);
+  void getStatsTransaction(packml_msgs::Stats& out_stats);
   packml_msgs::Stats populateStatsMsg(const packml_sm::PackmlStatsSnapshot& stats_snapshot);
   bool getStats(packml_msgs::GetStats::Request& req, packml_msgs::GetStats::Response& response);
   bool resetStats(packml_msgs::ResetStats::Request& req, packml_msgs::ResetStats::Response& response);

--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -33,41 +33,133 @@ namespace packml_ros
 class PackmlRos
 {
 public:
+
+  /**
+   * @brief Constructor for PackmlRos
+   *
+   * @param nh Private node handle
+   * @param pn Node handle
+   * @param sm Packml state machine
+   */
   PackmlRos(ros::NodeHandle nh, ros::NodeHandle pn, std::shared_ptr<packml_sm::AbstractStateMachine> sm);
+
+  /**
+   * @brief Destructor for PackmlRos
+   */
   ~PackmlRos();
+
+  /**
+   * @brief Overloads ros::spin()
+   */
   void spin();
+
+  /**
+   * @brief Overloads ros::spinOnce()
+   */
   void spinOnce();
 
 protected:
-  ros::NodeHandle nh_;
-  ros::NodeHandle pn_;
-  std::shared_ptr<packml_sm::AbstractStateMachine> sm_;
-  ros::Publisher status_pub_;
-  ros::Publisher stats_pub_;
-  ros::Publisher stats_transaction_pub_;
-  ros::ServiceServer trans_server_;
-  ros::ServiceServer reset_stats_server_;
-  ros::ServiceServer get_stats_server_;
-  ros::ServiceServer load_stats_server_;
-  packml_msgs::Status status_msg_;
-  double stats_publish_period_;
-  double stats_transaction_publish_period_;
-  ros::Timer stats_timer_;
-  ros::Timer stats_transaction_timer_;
+  ros::NodeHandle nh_;                                  /** Node handle */
+  ros::NodeHandle pn_;                                  /** Private node handle */
+  std::shared_ptr<packml_sm::AbstractStateMachine> sm_; /** Packml state machine */
+  ros::Publisher status_pub_;                           /** Publisher for Packml status */
+  ros::Publisher stats_pub_;                            /** Publisher for Packml stats */
+  ros::Publisher incremental_stats_pub_;                /** Publisher for incremental Packml stats */
+  ros::ServiceServer trans_server_;                     /** Advertises service to transition Packml state machine */
+  ros::ServiceServer reset_stats_server_;               /** Advertises service for resetting stats */
+  ros::ServiceServer get_stats_server_;                 /** Advertises service for getting stats */
+  ros::ServiceServer load_stats_server_;                /** Advertises service for loading stats */
+  packml_msgs::Status status_msg_;                      /** Message containing Packml status */
+  double stats_publish_rate_;                           /** Rate at which rolling Packml stats are calculated and published */
+  double incremental_stats_publish_rate_;               /** Rate at which incremental Packml stats are calculated and published */
+  ros::Timer stats_timer_;                              /** Timer used to publish Packml stats */
+  ros::Timer incremental_stats_timer_;                  /** Timer used to publish incremental Packml stats */
 
   bool transRequest(packml_msgs::Transition::Request& req, packml_msgs::Transition::Response& res);
 
 private:
+  /**
+   * @brief Event callback triggered on state change
+   *
+   * @param state_machine Packml state machine
+   * @param args Arguments for bound function
+   */
   void handleStateChanged(packml_sm::AbstractStateMachine& state_machine, const packml_sm::StateChangedEventArgs& args);
+
+  /**
+   * @brief Populates stats message with current Packml stats
+   *
+   * @param out_stats Stats message
+   */
   void getCurrentStats(packml_msgs::Stats& out_stats);
-  void getStatsTransaction(packml_msgs::Stats& out_stats);
+
+  /**
+   * @brief Pepulates stats message with current incremental Packml stats
+   *
+   * @param out_stats Stats message
+   */
+  void getIncrementalStats(packml_msgs::Stats &out_stats);
+
+  /**
+   * @brief Converts stats snapshot to stats message
+   *
+   * @param stats_snapshot data structure with stats data
+   * @return stats message
+   */
   packml_msgs::Stats populateStatsMsg(const packml_sm::PackmlStatsSnapshot& stats_snapshot);
+
+  /**
+   * @brief Service callback for getting stats
+   *
+   * @param req GetStats srv request
+   * @param response GesStats srv response
+   * @return success bool
+   */
   bool getStats(packml_msgs::GetStats::Request& req, packml_msgs::GetStats::Response& response);
+
+  /**
+   * @brief Service callback for resetting stats
+   *
+   * @param req ResetStats srv request
+   * @param response ResetStats srv response
+   * @return success bool
+   */
   bool resetStats(packml_msgs::ResetStats::Request& req, packml_msgs::ResetStats::Response& response);
+
+  /**
+   * @brief Service callback for loading stats
+   *
+   * @param req LoadStats srv request
+   * @param response LoadStats srv response
+   * @return success bool
+   */
   bool loadStats(packml_msgs::LoadStats::Request& req, packml_msgs::LoadStats::Response& response);
+
+  /**
+   * @brief Converts stats message to stats snapshot
+   *
+   * @param msg stats message
+   * @return stats snapshot
+   */
   packml_sm::PackmlStatsSnapshot populateStatsSnapshot(const packml_msgs::Stats& msg);
+
+  /**
+   * @brief Timer callback for publishing Packml stats
+   *
+   * @param timer_event ROS TimerEvent; not used
+   */
   void publishStatsCb(const ros::TimerEvent& timer_event);
-  void publishStatsTransactionCb(const ros::TimerEvent &timer_event);
+
+  /**
+   * @brief Timer callback for publishing incremental Packml stats
+   *
+   * @param timer_event ROS TimerEvent; not used
+   */
+  void publishIncrementalStatsCb(const ros::TimerEvent &timer_event);
+
+  /**
+   * @brief Publishes Packml stats
+   */
   void publishStats();
 };
 }  // namespace packml_ros

--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -44,13 +44,16 @@ protected:
   std::shared_ptr<packml_sm::AbstractStateMachine> sm_;
   ros::Publisher status_pub_;
   ros::Publisher stats_pub_;
+  ros::Publisher incremental_stats_pub_;
   ros::ServiceServer trans_server_;
   ros::ServiceServer reset_stats_server_;
   ros::ServiceServer get_stats_server_;
   ros::ServiceServer load_stats_server_;
   packml_msgs::Status status_msg_;
   float stats_publish_period_;
+  float incremental_stats_publish_period_;
   ros::Timer stats_timer_;
+  ros::Timer incremental_stats_timer_;
 
   bool transRequest(packml_msgs::Transition::Request& req, packml_msgs::Transition::Response& res);
 
@@ -62,6 +65,7 @@ private:
   bool loadStats(packml_msgs::LoadStats::Request& req, packml_msgs::LoadStats::Response& response);
   packml_sm::PackmlStatsSnapshot populateStatsSnapshot(const packml_msgs::Stats& msg);
   void publishStatsCb(const ros::TimerEvent& timer_event);
+  void publishIncrementalStatsCb(const ros::TimerEvent& timer_event);
   void publishStats();
 };
 }  // namespace packml_ros

--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -50,8 +50,8 @@ protected:
   ros::ServiceServer get_stats_server_;
   ros::ServiceServer load_stats_server_;
   packml_msgs::Status status_msg_;
-  float stats_publish_period_;
-  float stats_transaction_publish_period_;
+  double stats_publish_period_;
+  double stats_transaction_publish_period_;
   ros::Timer stats_timer_;
   ros::Timer stats_transaction_timer_;
 
@@ -60,7 +60,7 @@ protected:
 private:
   void handleStateChanged(packml_sm::AbstractStateMachine& state_machine, const packml_sm::StateChangedEventArgs& args);
   void getCurrentStats(packml_msgs::Stats& out_stats);
-  void getStatsTransaction(packml_msgs::Stats& out_stats);
+  void getStatsTransaction(packml_msgs::Stats& out_stats, double duration);
   packml_msgs::Stats populateStatsMsg(const packml_sm::PackmlStatsSnapshot& stats_snapshot);
   bool getStats(packml_msgs::GetStats::Request& req, packml_msgs::GetStats::Response& response);
   bool resetStats(packml_msgs::ResetStats::Request& req, packml_msgs::ResetStats::Response& response);

--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -44,28 +44,30 @@ protected:
   std::shared_ptr<packml_sm::AbstractStateMachine> sm_;
   ros::Publisher status_pub_;
   ros::Publisher stats_pub_;
-  ros::Publisher incremental_stats_pub_;
+  ros::Publisher stats_transaction_pub_;
   ros::ServiceServer trans_server_;
   ros::ServiceServer reset_stats_server_;
   ros::ServiceServer get_stats_server_;
   ros::ServiceServer load_stats_server_;
   packml_msgs::Status status_msg_;
   float stats_publish_period_;
-  float incremental_stats_publish_period_;
+  float stats_transaction_publish_period_;
   ros::Timer stats_timer_;
-  ros::Timer incremental_stats_timer_;
+  ros::Timer stats_transaction_timer_;
 
   bool transRequest(packml_msgs::Transition::Request& req, packml_msgs::Transition::Response& res);
 
 private:
   void handleStateChanged(packml_sm::AbstractStateMachine& state_machine, const packml_sm::StateChangedEventArgs& args);
   void getCurrentStats(packml_msgs::Stats& out_stats);
+  void getStatsTransaction(packml_msgs::Stats& out_stats);
+  packml_msgs::Stats populateStatsMsg(const packml_sm::PackmlStatsSnapshot& stats_snapshot);
   bool getStats(packml_msgs::GetStats::Request& req, packml_msgs::GetStats::Response& response);
   bool resetStats(packml_msgs::ResetStats::Request& req, packml_msgs::ResetStats::Response& response);
   bool loadStats(packml_msgs::LoadStats::Request& req, packml_msgs::LoadStats::Response& response);
   packml_sm::PackmlStatsSnapshot populateStatsSnapshot(const packml_msgs::Stats& msg);
   void publishStatsCb(const ros::TimerEvent& timer_event);
-  void publishIncrementalStatsCb(const ros::TimerEvent& timer_event);
+  void publishStatsTransactionCb(const ros::TimerEvent &timer_event);
   void publishStats();
 };
 }  // namespace packml_ros

--- a/packml_ros/launch/packml_ros.launch
+++ b/packml_ros/launch/packml_ros.launch
@@ -2,7 +2,7 @@
 <launch>
 
     <arg name="stats_publish_period" default="1.0" doc="Delay of stats messages publishing in seconds. 0 or less will not publish at all"/>
-    <arg name="stats_transaction_publish_period" default="1.0" doc="Delay of incremental stats messages calculating and publishing in seconds. 0 or less will not publish at all"/>
+    <arg name="stats_transaction_publish_period" default="900.0" doc="Delay of incremental stats messages calculating and publishing in seconds. 0 or less will not publish at all"/>
 
     <node name="packml_ros_node" pkg="packml_ros" type="packml_ros_node" output="screen">
         <param name="stats_publish_period" value="$(arg stats_publish_period)"/>

--- a/packml_ros/launch/packml_ros.launch
+++ b/packml_ros/launch/packml_ros.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 
-    <arg name="stats_publish_period" default="0.0" doc="Delay of stats messages publishing in seconds. 0 or less will not publish at all"/>
+    <arg name="stats_publish_period" default="1.0" doc="Delay of stats messages publishing in seconds. 0 or less will not publish at all"/>
     <arg name="stats_transaction_publish_period" default="1.0" doc="Delay of incremental stats messages calculating and publishing in seconds. 0 or less will not publish at all"/>
 
     <node name="packml_ros_node" pkg="packml_ros" type="packml_ros_node" output="screen">

--- a/packml_ros/launch/packml_ros.launch
+++ b/packml_ros/launch/packml_ros.launch
@@ -2,11 +2,11 @@
 <launch>
 
     <arg name="stats_publish_period" default="0.0" doc="Delay of stats messages publishing in seconds. 0 or less will not publish at all"/>
-    <arg name="incremental_stats_publish_period" default="1.0" doc="Delay of incremental stats messages calculating and publishing in seconds. 0 or less will not publish at all"/>
+    <arg name="stats_transaction_publish_period" default="1.0" doc="Delay of incremental stats messages calculating and publishing in seconds. 0 or less will not publish at all"/>
 
     <node name="packml_ros_node" pkg="packml_ros" type="packml_ros_node" output="screen">
         <param name="stats_publish_period" value="$(arg stats_publish_period)"/>
-        <param name="incremental_stats_publish_period" value="$(arg incremental_stats_publish_period)"/>
+        <param name="stats_transaction_publish_period" value="$(arg stats_transaction_publish_period)"/>
     </node>
 
 </launch>

--- a/packml_ros/launch/packml_ros.launch
+++ b/packml_ros/launch/packml_ros.launch
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <launch>
 
-    <arg name="stats_publish_period" default="1.0" doc="Rate at which rolling stats are calculated and published in seconds. 0 or less will not publish at all"/>
-    <arg name="stats_transaction_publish_period" default="900.0" doc="Rate at which incremental stats are calculated and published in seconds. 0 or less will not publish at all"/>
+    <arg name="stats_publish_rate" default="1.0" doc="Rate at which rolling stats are calculated and published in seconds. 0 or less will not publish at all"/>
+    <arg name="incremental_stats_publish_rate" default="900.0" doc="Rate at which incremental stats are calculated and published in seconds. 0 or less will not publish at all"/>
 
     <node name="packml_ros_node" pkg="packml_ros" type="packml_ros_node" output="screen">
-        <param name="stats_publish_period" value="$(arg stats_publish_period)"/>
-        <param name="stats_transaction_publish_period" value="$(arg stats_transaction_publish_period)"/>
+        <param name="stats_publish_rate" value="$(arg stats_publish_rate)"/>
+        <param name="incremental_stats_publish_rate" value="$(arg incremental_stats_publish_rate)"/>
     </node>
 
 </launch>

--- a/packml_ros/launch/packml_ros.launch
+++ b/packml_ros/launch/packml_ros.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="stats_publish_period" default="0.0" doc="Delay of stats messages publishing in seconds. 0 or less will not publish at all"/>
+    <arg name="incremental_stats_publish_period" default="1.0" doc="Delay of incremental stats messages calculating and publishing in seconds. 0 or less will not publish at all"/>
+
+    <node name="packml_ros_node" pkg="packml_ros" type="packml_ros_node" output="screen">
+        <param name="stats_publish_period" value="$(arg stats_publish_period)"/>
+        <param name="incremental_stats_publish_period" value="$(arg incremental_stats_publish_period)"/>
+    </node>
+
+</launch>

--- a/packml_ros/launch/packml_ros.launch
+++ b/packml_ros/launch/packml_ros.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
-    <arg name="stats_publish_period" default="1.0" doc="Delay of stats messages publishing in seconds. 0 or less will not publish at all"/>
-    <arg name="stats_transaction_publish_period" default="900.0" doc="Delay of incremental stats messages calculating and publishing in seconds. 0 or less will not publish at all"/>
+    <arg name="stats_publish_period" default="1.0" doc="Rate at which rolling stats are calculated and published in seconds. 0 or less will not publish at all"/>
+    <arg name="stats_transaction_publish_period" default="900.0" doc="Rate at which incremental stats are calculated and published in seconds. 0 or less will not publish at all"/>
 
     <node name="packml_ros_node" pkg="packml_ros" type="packml_ros_node" output="screen">
         <param name="stats_publish_period" value="$(arg stats_publish_period)"/>

--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -226,7 +226,6 @@ packml_msgs::Stats PackmlRos::populateStatsMsg(const packml_sm::PackmlStatsSnaps
   stats_msg.quality = stats_snapshot.quality;
   stats_msg.overall_equipment_effectiveness = stats_snapshot.overall_equipment_effectiveness;
 
-  stats_msg.error_items.clear();
   for (const auto& itemized_it : stats_snapshot.itemized_error_map)
   {
     packml_msgs::ItemizedStats stat;
@@ -236,7 +235,6 @@ packml_msgs::Stats PackmlRos::populateStatsMsg(const packml_sm::PackmlStatsSnaps
     stats_msg.error_items.push_back(stat);
   }
 
-  stats_msg.quality_items.clear();
   for (const auto& itemized_it : stats_snapshot.itemized_quality_map)
   {
     packml_msgs::ItemizedStats stat;
@@ -325,7 +323,7 @@ void PackmlRos::publishStatsCb(const ros::TimerEvent&)
 void PackmlRos::publishStats()
 {
   // Check if stats_publish_period changed
-  float stats_publish_period_new;
+  double stats_publish_period_new;
   if (pn_.getParam("stats_publish_period", stats_publish_period_new))
   {
     if (stats_publish_period_new != stats_publish_period_ && stats_publish_period_new > 0)
@@ -342,7 +340,7 @@ void PackmlRos::publishStats()
 void PackmlRos::publishStatsTransactionCb(const ros::TimerEvent &timer_event)
 {
   // Check if stats_transaction_publish_period changed
-  float stats_transaction_publish_period_new;
+  double stats_transaction_publish_period_new;
   if (pn_.getParam("stats_transaction_publish_period", stats_transaction_publish_period_new))
   {
     if (stats_transaction_publish_period_new != stats_transaction_publish_period_ && stats_transaction_publish_period_new > 0)

--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -200,10 +200,10 @@ void PackmlRos::getCurrentStats(packml_msgs::Stats& out_stats)
 }
 
 
-void PackmlRos::getStatsTransaction(packml_msgs::Stats &out_stats, double duration)
+void PackmlRos::getStatsTransaction(packml_msgs::Stats &out_stats)
 {
   packml_sm::PackmlStatsSnapshot stats_snapshot;
-  sm_->getCurrentStatTransaction(stats_snapshot, duration);
+  sm_->getCurrentStatTransaction(stats_snapshot);
   out_stats = populateStatsMsg(stats_snapshot);
 }
 
@@ -353,7 +353,7 @@ void PackmlRos::publishStatsTransactionCb(const ros::TimerEvent &timer_event)
   }
 
   packml_msgs::Stats stats;
-  getStatsTransaction(stats, stats_transaction_publish_period_new);
+  getStatsTransaction(stats);
   stats_transaction_pub_.publish(stats);
 }
 

--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -200,10 +200,10 @@ void PackmlRos::getCurrentStats(packml_msgs::Stats& out_stats)
 }
 
 
-void PackmlRos::getStatsTransaction(packml_msgs::Stats &out_stats)
+void PackmlRos::getStatsTransaction(packml_msgs::Stats &out_stats, double duration)
 {
   packml_sm::PackmlStatsSnapshot stats_snapshot;
-  sm_->getCurrentStatSnapshot(stats_snapshot);
+  sm_->getCurrentStatTransaction(stats_snapshot, duration);
   out_stats = populateStatsMsg(stats_snapshot);
 }
 
@@ -335,7 +335,7 @@ void PackmlRos::publishStats()
   }
 
   packml_msgs::Stats stats;
-  getStatsTransaction(stats);
+  getCurrentStats(stats);
   stats_pub_.publish(stats);
 }
 
@@ -348,12 +348,12 @@ void PackmlRos::publishStatsTransactionCb(const ros::TimerEvent &timer_event)
     if (stats_transaction_publish_period_new != stats_transaction_publish_period_ && stats_transaction_publish_period_new > 0)
     {
       stats_transaction_timer_ = nh_.createTimer(ros::Duration(stats_transaction_publish_period_new),
-                                                 &PackmlRos::publishStatsCb, this);
+                                                 &PackmlRos::publishStatsTransactionCb, this);
     }
   }
 
   packml_msgs::Stats stats;
-  getCurrentStats(stats);
+  getStatsTransaction(stats, stats_transaction_publish_period_new);
   stats_transaction_pub_.publish(stats);
 }
 

--- a/packml_sm/include/packml_sm/abstract_state_machine.h
+++ b/packml_sm/include/packml_sm/abstract_state_machine.h
@@ -397,6 +397,14 @@ public:
    */
   void getCurrentStatSnapshot(PackmlStatsSnapshot& snapshot_out);
 
+  /**
+   * @brief Fills the reference variable with the current stats transaction
+   *
+   * @param snapshot_out Reference to the variable to fill the transaction data with.
+   * @param period Amount of time for transaction
+   */
+  void getCurrentStatTransaction(PackmlStatsSnapshot& snapshot_out, double duration);
+
 protected:
   /**
    * @brief Call to invoke a state changed event.

--- a/packml_sm/include/packml_sm/abstract_state_machine.h
+++ b/packml_sm/include/packml_sm/abstract_state_machine.h
@@ -306,7 +306,7 @@ public:
   void resetStats();
 
   /**
-   * @brief Reset all of the tracked states.
+   * @brief Reset all of the tracked states for the current transaction.
    *
    */
   void resetTransactionStats();
@@ -423,7 +423,6 @@ public:
    * @brief Fills the reference variable with the current stats transaction
    *
    * @param snapshot_out Reference to the variable to fill the transaction data with.
-   * @param period Amount of time for transaction
    */
   void getCurrentStatTransaction(PackmlStatsSnapshot& snapshot_out);
 
@@ -506,7 +505,7 @@ private:
   std::map<StatesEnum, double> duration_map_; /** container for all of the durations referenced by their state id */
   std::map<StatesEnum, double> transaction_duration_map_; /** container for all of the durations referenced by their state id for the current transaction*/
   std::chrono::steady_clock::time_point start_time_; /** start time for the latest state entry */
-  std::chrono::steady_clock::time_point transaction_start_time_; /** start time for the latest state entry */
+  std::chrono::steady_clock::time_point transaction_start_time_; /** start time for the latest state entry for the current transaction*/
 
   /**
    * @brief adds or updates the specific itemized map

--- a/packml_sm/include/packml_sm/abstract_state_machine.h
+++ b/packml_sm/include/packml_sm/abstract_state_machine.h
@@ -35,8 +35,7 @@ namespace packml_sm
 class AbstractStateMachine
 {
 public:
-  EventHandler<AbstractStateMachine, StateChangedEventArgs> stateChangedEvent; /** Triggered during a state changed
-                                                                                  event. */
+  EventHandler<AbstractStateMachine, StateChangedEventArgs> stateChangedEvent; /** Triggered during a state changed event. */
 
   /**
    * @brief Constructor for AbstractStateMachine.
@@ -174,142 +173,142 @@ public:
   /**
    * @brief Accessor for the duration spent in idle time.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the idle state.
    */
-  double getIdleTime(bool is_transaction=false);
+  double getIdleTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in starting.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the starting state.
    */
-  double getStartingTime(bool is_transaction=false);
+  double getStartingTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in resetting.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the resetting state.
    */
-  double getResettingTime(bool is_transaction=false);
+  double getResettingTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in execute.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the execute state.
    */
-  double getExecuteTime(bool is_transaction=false);
+  double getExecuteTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in held.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the held state.
    */
-  double getHeldTime(bool is_transaction=false);
+  double getHeldTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in holding.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the holding state.
    */
-  double getHoldingTime(bool is_transaction=false);
+  double getHoldingTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in unholding.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the unholding state.
    */
-  double getUnholdingTime(bool is_transaction=false);
+  double getUnholdingTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in suspended.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the suspended state.
    */
-  double getSuspendedTime(bool is_transaction=false);
+  double getSuspendedTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in suspending.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the suspending state.
    */
-  double getSuspendingTime(bool is_transaction=false);
+  double getSuspendingTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in unsuspending.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the unsuspending state.
    */
-  double getUnsuspendingTime(bool is_transaction=false);
+  double getUnsuspendingTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in complete.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the complete state.
    */
-  double getCompleteTime(bool is_transaction=false);
+  double getCompleteTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in stopped.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the stopped state.
    */
-  double getStoppedTime(bool is_transaction=false);
+  double getStoppedTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in clearing.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the clearing state.
    */
-  double getClearingTime(bool is_transaction=false);
+  double getClearingTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in stopping.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the stopping state.
    */
-  double getStoppingTime(bool is_transaction=false);
+  double getStoppingTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in aborted.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the aborted state.
    */
-  double getAbortedTime(bool is_transaction=false);
+  double getAbortedTime(bool is_incremental=false);
 
   /**
    * @brief Accessor for the duration spent in aborting.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the time spent in the aborting state.
    */
-  double getAbortingTime(bool is_transaction=false);
+  double getAbortingTime(bool is_incremental=false);
 
   /**
-   * @brief Reset all of the tracked states.
+   * @brief Reset all of the tracked stats.
    *
    */
   void resetStats();
 
   /**
-   * @brief Reset all of the tracked states for the current transaction.
+   * @brief Reset all of the tracked incremental stats.
    *
    */
-  void resetTransactionStats();
+  void resetIncrementalStats();
 
   /**
    * @brief Load all of the tracked states.
@@ -420,11 +419,11 @@ public:
   void getCurrentStatSnapshot(PackmlStatsSnapshot& snapshot_out);
 
   /**
-   * @brief Fills the reference variable with the current stats transaction
+   * @brief Fills the reference variable with the current incremental stats
    *
-   * @param snapshot_out Reference to the variable to fill the transaction data with.
+   * @param snapshot_out Reference to the variable to fill the incremental stats data with.
    */
-  void getCurrentStatTransaction(PackmlStatsSnapshot& snapshot_out);
+  void getCurrentIncrementalStatSnapshot(PackmlStatsSnapshot &snapshot_out);
 
 protected:
   /**
@@ -490,22 +489,21 @@ protected:
   virtual void _abort() = 0;
 
 private:
-  std::map<int16_t, PackmlStatsItemized> itemized_error_map_;
-  std::map<int16_t, PackmlStatsItemized> transaction_itemized_error_map_;
-  std::map<int16_t, PackmlStatsItemized> itemized_quality_map_;
-  std::map<int16_t, PackmlStatsItemized> transaction_itemized_quality_map_;
-  int success_count_ = 0;              /** number of successful operations */
-  int success_count_transaction_ = 0;  /** number of successful operations */
-  int failure_count_ = 0;              /** number of failed operations */
-  int failure_count_transaction_ = 0;   /** number of failed operations */
-  float ideal_cycle_time_ = 0.0;       /** ideal cycle time in operations per second */
-
-  std::recursive_mutex stat_mutex_;                  /** stat mutex for protecting stat operations */
-  StatesEnum current_state_ = StatesEnum::UNDEFINED; /** cache of the current state */
-  std::map<StatesEnum, double> duration_map_; /** container for all of the durations referenced by their state id */
-  std::map<StatesEnum, double> transaction_duration_map_; /** container for all of the durations referenced by their state id for the current transaction*/
-  std::chrono::steady_clock::time_point start_time_; /** start time for the latest state entry */
-  std::chrono::steady_clock::time_point transaction_start_time_; /** start time for the latest state entry for the current transaction*/
+  std::map<int16_t, PackmlStatsItemized> itemized_error_map_;              /** count and duration of error items */
+  std::map<int16_t, PackmlStatsItemized> incremental_itemized_error_map_;  /** count and duration of error items for incremental stats */
+  std::map<int16_t, PackmlStatsItemized> itemized_quality_map_;            /** count and duration of quality items */
+  std::map<int16_t, PackmlStatsItemized> inremental_itemized_quality_map_; /** count and duration of quality items for incremental stats */
+  int success_count_ = 0;                                                  /** number of successful operations */
+  int incremental_success_count_ = 0;                                      /** number of successful operations for incremental stats */
+  int failure_count_ = 0;                                                  /** number of failed operations */
+  int incremental_failure_count_ = 0;                                      /** number of failed operations for incremental stats */
+  float ideal_cycle_time_ = 0.0;                                           /** ideal cycle time in operations per second */
+  std::recursive_mutex stat_mutex_;                                        /** stat mutex for protecting stat operations */
+  StatesEnum current_state_ = StatesEnum::UNDEFINED;                       /** cache of the current state */
+  std::map<StatesEnum, double> duration_map_;                              /** container for all of the durations referenced by their state id */
+  std::map<StatesEnum, double> incremental_duration_map_;                  /** container for all of the durations referenced by their state id for incremental stats */
+  std::chrono::steady_clock::time_point start_time_;                       /** start time for the latest state entry */
+  std::chrono::steady_clock::time_point incremental_start_time_;           /** start time for the latest state entry for incremental stats */
 
   /**
    * @brief adds or updates the specific itemized map
@@ -529,10 +527,10 @@ private:
    * @brief Accessor for the given state duration.
    *
    * @param state The state of interest.
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the total time spent in the given state.
    */
-  double getStateDuration(StatesEnum state, bool is_transaction=false);
+  double getStateDuration(StatesEnum state, bool is_incremental=false);
 
   /**
    * @brief Setter for the given state duration.
@@ -545,9 +543,9 @@ private:
   /**
    * @brief Accessor for the total duration of the state machine.
    *
-   * @param is_transaction=false flag to either calculate for a transaction or a running sum
+   * @param is_incremental=false flag to calculate stats incrementally or as a running sum
    * @return double Returns the total time spent in the state machine.
    */
-  double calculateTotalTime(bool is_transaction=false);
+  double calculateTotalTime(bool is_incremental=false);
 };
 }

--- a/packml_sm/include/packml_sm/abstract_state_machine.h
+++ b/packml_sm/include/packml_sm/abstract_state_machine.h
@@ -174,120 +174,142 @@ public:
   /**
    * @brief Accessor for the duration spent in idle time.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the idle state.
    */
-  double getIdleTime();
+  double getIdleTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in starting.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the starting state.
    */
-  double getStartingTime();
+  double getStartingTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in resetting.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the resetting state.
    */
-  double getResettingTime();
+  double getResettingTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in execute.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the execute state.
    */
-  double getExecuteTime();
+  double getExecuteTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in held.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the held state.
    */
-  double getHeldTime();
+  double getHeldTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in holding.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the holding state.
    */
-  double getHoldingTime();
+  double getHoldingTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in unholding.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the unholding state.
    */
-  double getUnholdingTime();
+  double getUnholdingTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in suspended.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the suspended state.
    */
-  double getSuspendedTime();
+  double getSuspendedTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in suspending.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the suspending state.
    */
-  double getSuspendingTime();
+  double getSuspendingTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in unsuspending.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the unsuspending state.
    */
-  double getUnsuspendingTime();
+  double getUnsuspendingTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in complete.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the complete state.
    */
-  double getCompleteTime();
+  double getCompleteTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in stopped.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the stopped state.
    */
-  double getStoppedTime();
+  double getStoppedTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in clearing.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the clearing state.
    */
-  double getClearingTime();
+  double getClearingTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in stopping.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the stopping state.
    */
-  double getStoppingTime();
+  double getStoppingTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in aborted.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the aborted state.
    */
-  double getAbortedTime();
+  double getAbortedTime(bool is_transaction);
 
   /**
    * @brief Accessor for the duration spent in aborting.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the aborting state.
    */
-  double getAbortingTime();
+  double getAbortingTime(bool is_transaction);
 
   /**
    * @brief Reset all of the tracked states.
    *
    */
   void resetStats();
+
+  /**
+   * @brief Reset all of the tracked states.
+   *
+   */
+  void resetTransactionStats();
 
   /**
    * @brief Load all of the tracked states.
@@ -470,15 +492,21 @@ protected:
 
 private:
   std::map<int16_t, PackmlStatsItemized> itemized_error_map_;
+  std::map<int16_t, PackmlStatsItemized> transaction_itemized_error_map_;
   std::map<int16_t, PackmlStatsItemized> itemized_quality_map_;
-  int success_count_ = 0;        /** number of successful operations */
-  int failure_count_ = 0;        /** number of failed operations */
-  float ideal_cycle_time_ = 0.0; /** ideal cycle time in operations per second */
+  std::map<int16_t, PackmlStatsItemized> transaction_itemized_quality_map_;
+  int success_count_ = 0;              /** number of successful operations */
+  int success_count_transaction_ = 0;  /** number of successful operations */
+  int failure_count_ = 0;              /** number of failed operations */
+  int failure_count_transaction_ = 0;   /** number of failed operations */
+  float ideal_cycle_time_ = 0.0;       /** ideal cycle time in operations per second */
 
   std::recursive_mutex stat_mutex_;                  /** stat mutex for protecting stat operations */
   StatesEnum current_state_ = StatesEnum::UNDEFINED; /** cache of the current state */
   std::map<StatesEnum, double> duration_map_; /** container for all of the durations referenced by their state id */
+  std::map<StatesEnum, double> transaction_duration_map_; /** container for all of the durations referenced by their state id for the current transaction*/
   std::chrono::steady_clock::time_point start_time_; /** start time for the latest state entry */
+  std::chrono::steady_clock::time_point transaction_start_time_; /** start time for the latest state entry */
 
   /**
    * @brief adds or updates the specific itemized map
@@ -502,9 +530,10 @@ private:
    * @brief Accessor for the given state duration.
    *
    * @param state The state of interest.
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the total time spent in the given state.
    */
-  double getStateDuration(StatesEnum state);
+  double getStateDuration(StatesEnum state, bool is_transaction);
 
   /**
    * @brief Setter for the given state duration.
@@ -517,8 +546,9 @@ private:
   /**
    * @brief Accessor for the total duration of the state machine.
    *
+   * @param is_transaction flag to either calculate for a transaction or a running sum
    * @return double Returns the total time spent in the state machine.
    */
-  double calculateTotalTime();
+  double calculateTotalTime(bool is_transaction);
 };
 }

--- a/packml_sm/include/packml_sm/abstract_state_machine.h
+++ b/packml_sm/include/packml_sm/abstract_state_machine.h
@@ -174,130 +174,130 @@ public:
   /**
    * @brief Accessor for the duration spent in idle time.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the idle state.
    */
-  double getIdleTime(bool is_transaction);
+  double getIdleTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in starting.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the starting state.
    */
-  double getStartingTime(bool is_transaction);
+  double getStartingTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in resetting.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the resetting state.
    */
-  double getResettingTime(bool is_transaction);
+  double getResettingTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in execute.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the execute state.
    */
-  double getExecuteTime(bool is_transaction);
+  double getExecuteTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in held.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the held state.
    */
-  double getHeldTime(bool is_transaction);
+  double getHeldTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in holding.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the holding state.
    */
-  double getHoldingTime(bool is_transaction);
+  double getHoldingTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in unholding.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the unholding state.
    */
-  double getUnholdingTime(bool is_transaction);
+  double getUnholdingTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in suspended.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the suspended state.
    */
-  double getSuspendedTime(bool is_transaction);
+  double getSuspendedTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in suspending.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the suspending state.
    */
-  double getSuspendingTime(bool is_transaction);
+  double getSuspendingTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in unsuspending.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the unsuspending state.
    */
-  double getUnsuspendingTime(bool is_transaction);
+  double getUnsuspendingTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in complete.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the complete state.
    */
-  double getCompleteTime(bool is_transaction);
+  double getCompleteTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in stopped.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the stopped state.
    */
-  double getStoppedTime(bool is_transaction);
+  double getStoppedTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in clearing.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the clearing state.
    */
-  double getClearingTime(bool is_transaction);
+  double getClearingTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in stopping.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the stopping state.
    */
-  double getStoppingTime(bool is_transaction);
+  double getStoppingTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in aborted.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the aborted state.
    */
-  double getAbortedTime(bool is_transaction);
+  double getAbortedTime(bool is_transaction=false);
 
   /**
    * @brief Accessor for the duration spent in aborting.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the time spent in the aborting state.
    */
-  double getAbortingTime(bool is_transaction);
+  double getAbortingTime(bool is_transaction=false);
 
   /**
    * @brief Reset all of the tracked states.
@@ -529,10 +529,10 @@ private:
    * @brief Accessor for the given state duration.
    *
    * @param state The state of interest.
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the total time spent in the given state.
    */
-  double getStateDuration(StatesEnum state, bool is_transaction);
+  double getStateDuration(StatesEnum state, bool is_transaction=false);
 
   /**
    * @brief Setter for the given state duration.
@@ -545,9 +545,9 @@ private:
   /**
    * @brief Accessor for the total duration of the state machine.
    *
-   * @param is_transaction flag to either calculate for a transaction or a running sum
+   * @param is_transaction=false flag to either calculate for a transaction or a running sum
    * @return double Returns the total time spent in the state machine.
    */
-  double calculateTotalTime(bool is_transaction);
+  double calculateTotalTime(bool is_transaction=false);
 };
 }

--- a/packml_sm/include/packml_sm/abstract_state_machine.h
+++ b/packml_sm/include/packml_sm/abstract_state_machine.h
@@ -425,7 +425,7 @@ public:
    * @param snapshot_out Reference to the variable to fill the transaction data with.
    * @param period Amount of time for transaction
    */
-  void getCurrentStatTransaction(PackmlStatsSnapshot& snapshot_out, double duration);
+  void getCurrentStatTransaction(PackmlStatsSnapshot& snapshot_out);
 
 protected:
   /**

--- a/packml_sm/src/abstract_state_machine.cpp
+++ b/packml_sm/src/abstract_state_machine.cpp
@@ -175,17 +175,17 @@ bool AbstractStateMachine::abort()
 void AbstractStateMachine::getCurrentStatSnapshot(PackmlStatsSnapshot& snapshot_out)
 {
   std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
-  auto scheduled_time = calculateTotalTime(false);
+  auto scheduled_time = calculateTotalTime();
   float throughput = 0.0f;
   if (scheduled_time > std::numeric_limits<double>::epsilon())
   {
     throughput = success_count_ / scheduled_time;
   }
 
-  auto held_time = getHeldTime(false);
-  auto stopped_time = getStoppedTime(false);
-  auto suspend_time = getSuspendedTime(false);
-  auto aborted_time = getAbortedTime(false);
+  auto held_time = getHeldTime();
+  auto stopped_time = getStoppedTime();
+  auto suspend_time = getSuspendedTime();
+  auto aborted_time = getAbortedTime();
 
   auto operating_time = scheduled_time;
   operating_time -= stopped_time;
@@ -212,11 +212,11 @@ void AbstractStateMachine::getCurrentStatSnapshot(PackmlStatsSnapshot& snapshot_
   }
 
   snapshot_out.duration = scheduled_time;
-  snapshot_out.idle_duration = getIdleTime(false);
-  snapshot_out.exe_duration = getExecuteTime(false);
+  snapshot_out.idle_duration = getIdleTime();
+  snapshot_out.exe_duration = getExecuteTime();
   snapshot_out.held_duration = held_time;
   snapshot_out.susp_duration = suspend_time;
-  snapshot_out.cmplt_duration = getCompleteTime(false);
+  snapshot_out.cmplt_duration = getCompleteTime();
   snapshot_out.stop_duration = stopped_time;
   snapshot_out.abort_duration = aborted_time;
   snapshot_out.success_count = success_count_;

--- a/packml_sm/src/abstract_state_machine.cpp
+++ b/packml_sm/src/abstract_state_machine.cpp
@@ -230,7 +230,7 @@ void AbstractStateMachine::getCurrentStatSnapshot(PackmlStatsSnapshot& snapshot_
   snapshot_out.itemized_quality_map = itemized_quality_map_;
 }
 
-void AbstractStateMachine::getCurrentStatTransaction(PackmlStatsSnapshot &snapshot_out, double duration)
+void AbstractStateMachine::getCurrentStatTransaction(PackmlStatsSnapshot &snapshot_out)
 {
   std::lock_guard<std::recursive_mutex> lock(stat_mutex_);
   auto scheduled_time = calculateTotalTime(true);

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -304,7 +304,7 @@ TEST(Packml_CC, getCurrentStatTransaction_empty)
   std::shared_ptr<AbstractStateMachine> sm = PackmlStateMachineContinuous::spawn();
 
   packml_sm::PackmlStatsSnapshot snapshot_out;
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
 
   ASSERT_LT(snapshot_out.duration, 1);
   ASSERT_EQ(snapshot_out.idle_duration, 0);
@@ -388,7 +388,7 @@ TEST(Packml_CC, getCurrentStatTransaction_durations)
   ASSERT_TRUE(waitForState(StatesEnum::ABORTED, queue));
   ros::Duration(2.0).sleep();
 
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_NEAR(snapshot_out.duration, 16, 1);
   ASSERT_NEAR(snapshot_out.abort_duration, 4, 1);
   ASSERT_NEAR(snapshot_out.stop_duration, 4, 1);
@@ -399,7 +399,7 @@ TEST(Packml_CC, getCurrentStatTransaction_durations)
   ASSERT_NEAR(snapshot_out.held_duration, 0, 1);
 
   // Ensure durations reset after transaction
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_NEAR(snapshot_out.duration, 0, 1);
   ASSERT_NEAR(snapshot_out.abort_duration, 0, 1);
   ASSERT_NEAR(snapshot_out.stop_duration, 0, 1);
@@ -411,7 +411,7 @@ TEST(Packml_CC, getCurrentStatTransaction_durations)
 
   // Next transaction
   ros::Duration(2.0).sleep();
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_NEAR(snapshot_out.duration, 2, 1);
   ASSERT_NEAR(snapshot_out.abort_duration, 2, 1);
 
@@ -435,14 +435,14 @@ TEST(Packml_CC, getCurrentStatTransaction_counts)
     sm->incrementFailureCount();
   }
 
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_EQ(snapshot_out.success_count, 90);
   ASSERT_EQ(snapshot_out.fail_count, 10);
   ASSERT_GT(snapshot_out.throughput, 90);
   ASSERT_NEAR(snapshot_out.quality, 0.9, 0.001);
 
   // Ensure counts reset after transaction
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_EQ(snapshot_out.success_count, 0);
   ASSERT_EQ(snapshot_out.fail_count, 0);
   ASSERT_EQ(snapshot_out.throughput, 0);
@@ -453,7 +453,7 @@ TEST(Packml_CC, getCurrentStatTransaction_counts)
   {
     sm->incrementSuccessCount();
   }
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_EQ(snapshot_out.success_count, 90);
   ASSERT_EQ(snapshot_out.fail_count, 0);
   ASSERT_GT(snapshot_out.throughput, 90);
@@ -471,7 +471,7 @@ TEST(Packml_CC, getCurrentStatTransaction_items)
   sm->incrementQualityStatItem(1, 5, 15);
   sm->incrementErrorStatItem(2, 7, 30);
 
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_EQ(snapshot_out.itemized_quality_map.size(), 1);
   ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).count, 5);
   ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).duration, 15);
@@ -480,7 +480,7 @@ TEST(Packml_CC, getCurrentStatTransaction_items)
   ASSERT_EQ(snapshot_out.itemized_error_map.at(2).duration, 30);
 
   // Ensure map items' counts and durations reset after transaction
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_EQ(snapshot_out.itemized_quality_map.size(), 1);
   ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).count, 0);
   ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).duration, 0);
@@ -490,7 +490,7 @@ TEST(Packml_CC, getCurrentStatTransaction_items)
 
   // Next transaction
   sm->incrementQualityStatItem(1, 88, 150);
-  sm->getCurrentStatTransaction(snapshot_out);
+  sm->getCurrentIncrementalStatSnapshot(snapshot_out);
   ASSERT_EQ(snapshot_out.itemized_quality_map.size(), 1);
   ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).count, 88);
   ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).duration, 150);

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -298,4 +298,204 @@ TEST(Packml_CC, load_stats)
   ROS_INFO_STREAM("load stats test complete");
 }
 
+TEST(Packml_CC, getCurrentStatTransaction_empty)
+{
+  ROS_INFO_STREAM("CONTINUOUS CYCLE::stats transaction empty");
+  std::shared_ptr<AbstractStateMachine> sm = PackmlStateMachineContinuous::spawn();
+
+  packml_sm::PackmlStatsSnapshot snapshot_out;
+  sm->getCurrentStatTransaction(snapshot_out);
+
+  ASSERT_LT(snapshot_out.duration, 1);
+  ASSERT_EQ(snapshot_out.idle_duration, 0);
+  ASSERT_EQ(snapshot_out.exe_duration, 0);
+  ASSERT_EQ(snapshot_out.held_duration, 0);
+  ASSERT_EQ(snapshot_out.susp_duration, 0);
+  ASSERT_EQ(snapshot_out.cmplt_duration, 0);
+  ASSERT_EQ(snapshot_out.stop_duration, 0);
+  ASSERT_EQ(snapshot_out.abort_duration, 0);
+
+  ASSERT_EQ(snapshot_out.success_count, 0);
+  ASSERT_EQ(snapshot_out.fail_count, 0);
+  ASSERT_EQ(snapshot_out.cycle_count, 0);
+  ASSERT_EQ(snapshot_out.throughput, 0);
+
+  ASSERT_EQ(snapshot_out.availability, 1);
+  ASSERT_EQ(snapshot_out.performance, 0);
+  ASSERT_EQ(snapshot_out.quality, 0);
+  ASSERT_EQ(snapshot_out.overall_equipment_effectiveness, 0);
+
+  ASSERT_EQ(snapshot_out.itemized_error_map.size(), 0);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.size(), 0);
+
+  ROS_INFO_STREAM("stats transaction empty complete");
+}
+
+TEST(Packml_CC, getCurrentStatTransaction_durations)
+{
+  ROS_INFO_STREAM("CONTINUOUS CYCLE::stats transaction durations");
+  std::shared_ptr<AbstractStateMachine> sm = PackmlStateMachineContinuous::spawn();
+  StateMachineVisitedStatesQueue queue(sm);
+  packml_sm::PackmlStatsSnapshot snapshot_out;
+
+  sm->setExecute(std::bind(success));
+  sm->activate();
+  while (!sm->isActive()) { }
+
+  ASSERT_TRUE(waitForState(StatesEnum::ABORTED, queue));
+  ros::Duration(2.0).sleep();
+
+  ASSERT_TRUE(sm->clear());
+  ASSERT_TRUE(waitForState(StatesEnum::CLEARING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::STOPPED, queue));
+  ros::Duration(2.0).sleep();
+
+  ASSERT_TRUE(sm->reset());
+  ASSERT_TRUE(waitForState(StatesEnum::RESETTING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::IDLE, queue));
+  ros::Duration(2.0).sleep();
+
+  ASSERT_TRUE(sm->start());
+  ASSERT_TRUE(waitForState(StatesEnum::STARTING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::EXECUTE, queue));
+  ASSERT_FALSE(waitForState(StatesEnum::COMPLETING, queue));
+  ASSERT_FALSE(waitForState(StatesEnum::COMPLETE, queue));
+
+  ASSERT_TRUE(sm->hold());
+  ASSERT_TRUE(waitForState(StatesEnum::HOLDING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::HELD, queue));
+
+  ASSERT_TRUE(sm->unhold());
+  ASSERT_TRUE(waitForState(StatesEnum::UNHOLDING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::EXECUTE, queue));
+
+  ASSERT_TRUE(sm->suspend());
+  ASSERT_TRUE(waitForState(StatesEnum::SUSPENDING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::SUSPENDED, queue));
+  ros::Duration(2.0).sleep();
+
+  ASSERT_TRUE(sm->unsuspend());
+  ASSERT_TRUE(waitForState(StatesEnum::UNSUSPENDING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::EXECUTE, queue));
+
+  ASSERT_TRUE(sm->stop());
+  ASSERT_TRUE(waitForState(StatesEnum::STOPPING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::STOPPED, queue));
+  ros::Duration(2.0).sleep();
+
+  ASSERT_TRUE(sm->abort());
+  ASSERT_TRUE(waitForState(StatesEnum::ABORTING, queue));
+  ASSERT_TRUE(waitForState(StatesEnum::ABORTED, queue));
+  ros::Duration(2.0).sleep();
+
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_NEAR(snapshot_out.duration, 16, 1);
+  ASSERT_NEAR(snapshot_out.abort_duration, 4, 1);
+  ASSERT_NEAR(snapshot_out.stop_duration, 4, 1);
+  ASSERT_NEAR(snapshot_out.idle_duration, 2, 1);
+  ASSERT_NEAR(snapshot_out.exe_duration, 4, 1);
+  ASSERT_NEAR(snapshot_out.cmplt_duration, 0, 1);
+  ASSERT_NEAR(snapshot_out.susp_duration, 2, 1);
+  ASSERT_NEAR(snapshot_out.held_duration, 0, 1);
+
+  // Ensure durations reset after transaction
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_NEAR(snapshot_out.duration, 0, 1);
+  ASSERT_NEAR(snapshot_out.abort_duration, 0, 1);
+  ASSERT_NEAR(snapshot_out.stop_duration, 0, 1);
+  ASSERT_NEAR(snapshot_out.idle_duration, 0, 1);
+  ASSERT_NEAR(snapshot_out.exe_duration, 0, 1);
+  ASSERT_NEAR(snapshot_out.cmplt_duration, 0, 1);
+  ASSERT_NEAR(snapshot_out.susp_duration, 0, 1);
+  ASSERT_NEAR(snapshot_out.held_duration, 0, 1);
+
+  // Next transaction
+  ros::Duration(2.0).sleep();
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_NEAR(snapshot_out.duration, 2, 1);
+  ASSERT_NEAR(snapshot_out.abort_duration, 2, 1);
+
+  ROS_INFO_STREAM("stats transaction durations complete");
+}
+
+TEST(Packml_CC, getCurrentStatTransaction_counts)
+{
+  ROS_INFO_STREAM("CONTINUOUS CYCLE::stats transaction counts");
+  std::shared_ptr<AbstractStateMachine> sm = PackmlStateMachineContinuous::spawn();
+  packml_sm::PackmlStatsSnapshot snapshot_out;
+
+  auto num_successes = 90;
+  auto num_failures = 10;
+  for (auto i = 0; i < num_successes; ++i)
+  {
+    sm->incrementSuccessCount();
+  }
+  for (auto i = 0; i < num_failures; ++i)
+  {
+    sm->incrementFailureCount();
+  }
+
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_EQ(snapshot_out.success_count, 90);
+  ASSERT_EQ(snapshot_out.fail_count, 10);
+  ASSERT_GT(snapshot_out.throughput, 90);
+  ASSERT_NEAR(snapshot_out.quality, 0.9, 0.001);
+
+  // Ensure counts reset after transaction
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_EQ(snapshot_out.success_count, 0);
+  ASSERT_EQ(snapshot_out.fail_count, 0);
+  ASSERT_EQ(snapshot_out.throughput, 0);
+  ASSERT_EQ(snapshot_out.quality, 0);
+
+  // Next transaction
+  for (auto i = 0; i < num_successes; ++i)
+  {
+    sm->incrementSuccessCount();
+  }
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_EQ(snapshot_out.success_count, 90);
+  ASSERT_EQ(snapshot_out.fail_count, 0);
+  ASSERT_GT(snapshot_out.throughput, 90);
+  ASSERT_NEAR(snapshot_out.quality, 1.0, 0.001);
+
+  ROS_INFO_STREAM("stats transaction durations counts");
+}
+
+TEST(Packml_CC, getCurrentStatTransaction_items)
+{
+  ROS_INFO_STREAM("CONTINUOUS CYCLE::stats transaction items");
+  std::shared_ptr<AbstractStateMachine> sm = PackmlStateMachineContinuous::spawn();
+  packml_sm::PackmlStatsSnapshot snapshot_out;
+
+  sm->incrementQualityStatItem(1, 5, 15);
+  sm->incrementErrorStatItem(2, 7, 30);
+
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.size(), 1);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).count, 5);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).duration, 15);
+  ASSERT_EQ(snapshot_out.itemized_error_map.size(), 1);
+  ASSERT_EQ(snapshot_out.itemized_error_map.at(2).count, 7);
+  ASSERT_EQ(snapshot_out.itemized_error_map.at(2).duration, 30);
+
+  // Ensure map items' counts and durations reset after transaction
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.size(), 1);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).count, 0);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).duration, 0);
+  ASSERT_EQ(snapshot_out.itemized_error_map.size(), 1);
+  ASSERT_EQ(snapshot_out.itemized_error_map.at(2).count, 0);
+  ASSERT_EQ(snapshot_out.itemized_error_map.at(2).duration, 0);
+
+  // Next transaction
+  sm->incrementQualityStatItem(1, 88, 150);
+  sm->getCurrentStatTransaction(snapshot_out);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.size(), 1);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).count, 88);
+  ASSERT_EQ(snapshot_out.itemized_quality_map.at(1).duration, 150);
+
+  ROS_INFO_STREAM("stats transaction durations items");
+}
+
 }


### PR DESCRIPTION
Adds logic to publish packml stats incrementally as transactions based on a launch parameter. This new logic largely follows the previously stats publishing functionality, with the major exception being that it resets stats every time they are published, forcing the stats to be calculated at the same rate as they are published. 

The following testing log shows a 30s transaction period (default is 15mins). One can see that the durations are only calculated for the current transaction, so that as the robot moves from aborted -> idle -> executing, the previous information is not persisted. Both the durations and other stats are more fully tested in unit tests included in this pull request.

```
charlescostello@plusonerobotics:~/Projects/packml_ws$ rostopic echo /packml/stats_transaction
header:
  seq: 0
  stamp:
    secs: 1569445530
    nsecs:  35427553
  frame_id: ''
duration:
  data:
    secs: 30
    nsecs:   9771573
idle_duration:
  data:
    secs: 0
    nsecs:         0
exe_duration:
  data:
    secs: 0
    nsecs:         0
held_duration:
  data:
    secs: 0
    nsecs:         0
susp_duration:
  data:
    secs: 0
    nsecs:         0
cmplt_duration:
  data:
    secs: 0
    nsecs:         0
stop_duration:
  data:
    secs: 0
    nsecs:         0
abort_duration:
  data:
    secs: 30
    nsecs:   2091358
error_items: []
quality_items: []
cycle_count: 0
success_count: 0
fail_count: 0
throughput: 0.0
availability: 0.000255923805526
performance: 0.0
quality: 0.0
overall_equipment_effectiveness: 0.0
---
header:
  seq: 1
  stamp:
    secs: 1569445560
    nsecs:  34877827
  frame_id: ''
duration:
  data:
    secs: 29
    nsecs: 999445291
idle_duration:
  data:
    secs: 7
    nsecs: 654985830
exe_duration:
  data:
    secs: 0
    nsecs:         0
held_duration:
  data:
    secs: 0
    nsecs:         0
susp_duration:
  data:
    secs: 0
    nsecs:         0
cmplt_duration:
  data:
    secs: 0
    nsecs:         0
stop_duration:
  data:
    secs: 0
    nsecs: 903235361
abort_duration:
  data:
    secs: 10
    nsecs: 518651268
error_items: []
quality_items: []
cycle_count: 0
success_count: 0
fail_count: 0
throughput: 0.0
availability: 0.619263410568
performance: 0.0
quality: 0.0
overall_equipment_effectiveness: 0.0
---
header:
  seq: 2
  stamp:
    secs: 1569445590
    nsecs:  38292255
  frame_id: ''
duration:
  data:
    secs: 30
    nsecs:   3397736
idle_duration:
  data:
    secs: 8
    nsecs:  75207772
exe_duration:
  data:
    secs: 21
    nsecs: 824579379
held_duration:
  data:
    secs: 0
    nsecs:         0
susp_duration:
  data:
    secs: 0
    nsecs:         0
cmplt_duration:
  data:
    secs: 0
    nsecs:         0
stop_duration:
  data:
    secs: 0
    nsecs:         0
abort_duration:
  data:
    secs: 0
    nsecs:         0
error_items: []
quality_items: []
cycle_count: 0
success_count: 0
fail_count: 0
throughput: 0.0
availability: 1.0
performance: 0.0
quality: 0.0
overall_equipment_effectiveness: 0.0
---
``` 