### PR TITLE
Setting cycle_count as the sum of success counts and fail counts

### DIFF
--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -204,6 +204,7 @@ packml_msgs::Stats PackmlRos::populateStatsMsg(const packml_sm::PackmlStatsSnaps
 {
   packml_msgs::Stats stats_msg;
 
+  stats_msg.cycle_count = stats_snapshot.cycle_count;
   stats_msg.idle_duration.data.fromSec(stats_snapshot.idle_duration);
   stats_msg.exe_duration.data.fromSec(stats_snapshot.exe_duration);
   stats_msg.held_duration.data.fromSec(stats_snapshot.held_duration);

--- a/packml_sm/src/abstract_state_machine.cpp
+++ b/packml_sm/src/abstract_state_machine.cpp
@@ -211,6 +211,7 @@ void AbstractStateMachine::getCurrentStatSnapshot(PackmlStatsSnapshot& snapshot_
     quality = static_cast<float>(success_count_) / static_cast<float>(total_count);
   }
 
+  snapshot_out.cycle_count = total_count;
   snapshot_out.duration = scheduled_time;
   snapshot_out.idle_duration = getIdleTime();
   snapshot_out.exe_duration = getExecuteTime();
@@ -269,6 +270,7 @@ void AbstractStateMachine::getCurrentIncrementalStatSnapshot(PackmlStatsSnapshot
     quality = static_cast<float>(incremental_success_count_) / static_cast<float>(total_count);
   }
 
+  snapshot_out.cycle_count = total_count;
   snapshot_out.duration = scheduled_time;
   snapshot_out.idle_duration = getIdleTime(true);
   snapshot_out.exe_duration = getExecuteTime(true);


### PR DESCRIPTION
Solves [this](https://gitlab.com/plusone-robotics/core/core/-/issues/284) issue.

Initial behavior:
Even if we increase the success_count or fail_count, the cycle count was always set to 0.

```
$ rosservice call /packml_ros_node/packml/get_stats {}
stats: 
  header: 
    seq: 0
    stamp: 
      secs: 1588604406
      nsecs: 967276398
    frame_id: ''
  duration: 
    data: 
      secs: 59
      nsecs: 901049908
  idle_duration: 
    data: 
      secs: 0
      nsecs:         0
  exe_duration: 
    data: 
      secs: 0
      nsecs:         0
  held_duration: 
    data: 
      secs: 0
      nsecs:         0
  susp_duration: 
    data: 
      secs: 0
      nsecs:         0
  cmplt_duration: 
    data: 
      secs: 0
      nsecs:         0
  stop_duration: 
    data: 
      secs: 0
      nsecs:         0
  abort_duration: 
    data: 
      secs: 59
      nsecs: 443034090
  error_items: []
  quality_items: []
  cycle_count: 0
  success_count: 1
  fail_count: 1
  throughput: 0.0
  availability: 0.00764620676637
  performance: 0.0
  quality: 0.5
  overall_equipment_effectiveness: 0.0
```

Expected and Current behavior:
When we increase the success_count or fail_count, the cycle count is set to (success_count + failure_count)

```
$ rosservice call /packml_ros_node/packml/get_stats {}
stats: 
  header: 
    seq: 0
    stamp: 
      secs: 1588602924
      nsecs: 460964510
    frame_id: ''
  duration: 
    data: 
      secs: 49
      nsecs: 834924419
  idle_duration: 
    data: 
      secs: 0
      nsecs:         0
  exe_duration: 
    data: 
      secs: 0
      nsecs:         0
  held_duration: 
    data: 
      secs: 0
      nsecs:         0
  susp_duration: 
    data: 
      secs: 0
      nsecs:         0
  cmplt_duration: 
    data: 
      secs: 0
      nsecs:         0
  stop_duration: 
    data: 
      secs: 0
      nsecs:         0
  abort_duration: 
    data: 
      secs: 49
      nsecs: 343956963
  error_items: []
  quality_items: []
  cycle_count: 2
  success_count: 1
  fail_count: 1
  throughput: 0.0
  availability: 0.00985187478364
  performance: 0.0
  quality: 0.5
  overall_equipment_effectiveness: 0.0
```