### PR TITLE
Setting the ieal cycle time parameter 

### DIFF
--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -80,6 +80,7 @@ protected:
   packml_msgs::Status status_msg_;                      /** Message containing Packml status */
   double stats_publish_rate_;                           /** Rate at which rolling Packml stats are calculated and published */
   double incremental_stats_publish_rate_;               /** Rate at which incremental Packml stats are calculated and published */
+  double ideal_cycle_time_;				/** Ideal time for a cycle used to calculate performance and OEE*/
   ros::Timer stats_timer_;                              /** Timer used to publish Packml stats */
   ros::Timer incremental_stats_timer_;                  /** Timer used to publish incremental Packml stats */
 

--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -77,8 +77,15 @@ PackmlRos::PackmlRos(ros::NodeHandle nh, ros::NodeHandle pn, std::shared_ptr<pac
                                                &PackmlRos::publishIncrementalStatsCb, this);
   }
 
+  if (!pn_.getParam("ideal_cycle_time", ideal_cycle_time_))
+  {
+    ROS_WARN_STREAM("Missing param: ideal_cycle_time. Defaulting to 0.1 second");
+    ideal_cycle_time_ = 0.1;
+  }
+
   sm_->stateChangedEvent.bind_member_func(this, &PackmlRos::handleStateChanged);
   sm_->activate();
+  sm_->setIdealCycleTime(ideal_cycle_time_);
 
 }
 


### PR DESCRIPTION
Closes: https://gitlab.com/plusone-robotics/bolles/bolles/-/issues/608

After this change:

1) Able to set ideal_cycle_time at load from a config file
2) Able to calculate performance and OEE which were previously set to 0.0 always

```
$ rosservice call /packml_ros_node/packml/inc_stat '{metric: 1, step: 1}'

$ rosservice call /packml_ros_node/packml/get_stats {}
stats: 
  header: 
    seq: 0
    stamp: 
      secs: 1588688948
      nsecs: 563417743
    frame_id: ''
  duration: 
    data: 
      secs: 18
      nsecs: 115576377
  idle_duration: 
    data: 
      secs: 0
      nsecs:         0
  exe_duration: 
    data: 
      secs: 0
      nsecs:         0
  held_duration: 
    data: 
      secs: 0
      nsecs:         0
  susp_duration: 
    data: 
      secs: 0
      nsecs:         0
  cmplt_duration: 
    data: 
      secs: 0
      nsecs:         0
  stop_duration: 
    data: 
      secs: 0
      nsecs:         0
  abort_duration: 
    data: 
      secs: 17
      nsecs: 619463653
  error_items: []
  quality_items: []
  cycle_count: 0
  success_count: 1
  fail_count: 0
  throughput: 0.0
  availability: 0.0273859743029
  performance: 0.201567098498
  quality: 1.0
  overall_equipment_effectiveness: 0.00552011141554
```

Blocked by https://gitlab.com/plusone-robotics/bolles/bolles_tools/-/merge_requests/247
