### PR TITLE
Update to c++ 14

### DIFF
--- a/packml_ros/CMakeLists.txt
+++ b/packml_ros/CMakeLists.txt
@@ -17,18 +17,18 @@ catkin_package(
 include_directories(include ${catkin_INCLUDE_DIRS})
 add_library(${PROJECT_NAME} src/packml_ros.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-target_compile_options(${PROJECT_NAME} PUBLIC -std=c++11)
+target_compile_options(${PROJECT_NAME} PUBLIC -std=c++14)
 
 add_executable(packml_ros_node src/packml_ros_node.cpp)
 target_link_libraries(packml_ros_node ${PROJECT_NAME} ${catkin_LIBRARIES})
-target_compile_options(packml_ros_node PUBLIC -std=c++11)
+target_compile_options(packml_ros_node PUBLIC -std=c++14)
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest)
   set(UTEST_SRC_FILES test/utest.cpp)
 
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
-  target_compile_options(${PROJECT_NAME}_utest PUBLIC -std=c++11)
+  target_compile_options(${PROJECT_NAME}_utest PUBLIC -std=c++14)
   target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME} ${catkin_LIBRARIES})
 endif()
 

--- a/packml_sm/CMakeLists.txt
+++ b/packml_sm/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_library(${PROJECT_NAME} ${packml_sm_SRCS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 target_compile_definitions(${PROJECT_NAME} PUBLIC -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS PUBLIC -DBOOST_MPL_LIMIT_VECTOR_SIZE=60 PUBLIC -DBOOST_MPL_LIMIT_MAP_SIZE=60 PUBLIC -DFUSION_MAX_VECTOR_SIZE=50)
-target_compile_options(${PROJECT_NAME} PUBLIC -std=c++11)
+target_compile_options(${PROJECT_NAME} PUBLIC -std=c++14)
 
 #############
 ## Install ##

--- a/packml_sm/CMakeLists.txt
+++ b/packml_sm/CMakeLists.txt
@@ -68,6 +68,6 @@ if(CATKIN_ENABLE_TESTING)
       )
 
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
-  target_compile_options(${PROJECT_NAME}_utest PUBLIC -std=c++11)
+  target_compile_options(${PROJECT_NAME}_utest PUBLIC -std=c++14)
   target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
 endif()

--- a/packml_stacklight/CMakeLists.txt
+++ b/packml_stacklight/CMakeLists.txt
@@ -35,11 +35,11 @@ include_directories(${${PROJECT_NAME}_INCLUDE_DIRECTORIES} ${catkin_INCLUDE_DIRS
 
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-target_compile_options(${PROJECT_NAME} PUBLIC -std=c++11)
+target_compile_options(${PROJECT_NAME} PUBLIC -std=c++14)
 
 add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp)
 target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME} ${catkin_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_node PUBLIC -std=c++11)
+target_compile_options(${PROJECT_NAME}_node PUBLIC -std=c++14)
 
 install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -60,6 +60,6 @@ if(CATKIN_ENABLE_TESTING)
   set(UTEST_SRC_FILES test/test_stacklight.cpp)
 
   catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
-  target_compile_options(${PROJECT_NAME}_utest PUBLIC -std=c++11)
+  target_compile_options(${PROJECT_NAME}_utest PUBLIC -std=c++14)
   target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
 endif()

--- a/packml_stats_loader/CMakeLists.txt
+++ b/packml_stats_loader/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(packml_stats_loader)
 
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 find_package(catkin REQUIRED COMPONENTS
   packml_msgs


### PR DESCRIPTION
When building from source in Ubuntu 24.04, with CMake 3.28.3, we observe the following warning:

```sh
Warnings   << packml_sm:make /ws/logs/packml_sm/build.make.000.log                                                                                                                   
In file included from /usr/include/boost/math/special_functions/round.hpp:14,
                 from /opt/ros/noetic/include/ros/time.h:58,
                 from /opt/ros/noetic/include/ros/console.h:39,
                 from /ws/src/plusone-robotics/packml/packml_sm/src/ros/dlog.cpp:23:
/usr/include/boost/math/tools/config.hpp:23:6: warning: #warning "The minimum language standard to use Boost.Math will be C++14 starting in July 2023 (Boost 1.82 release)" [-Wcpp]
   23 | #    warning "The minimum language standard to use Boost.Math will be C++14 starting in July 2023 (Boost 1.82 release)"
```

Updating will suppress this warning.